### PR TITLE
Add examination results for Phase2 datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,5 +14,5 @@ To assess, review the data examination results that compare federal
 agency tax estimates with those generated using the microdata file
 created in each project phase: [phase 1
 results](./tax_microdata_benchmarking/examination/results1.md) and
-(the as yet only partially complete) [phase 2
+[phase 2
 results](./tax_microdata_benchmarking/examination/results2.md).

--- a/tax_microdata_benchmarking/create_flat_file.py
+++ b/tax_microdata_benchmarking/create_flat_file.py
@@ -31,7 +31,7 @@ class tc_MARS(TaxCalcVariableAlias):
             "JOINT": 2,
             "SEPARATE": 3,
             "HEAD_OF_HOUSEHOLD": 4,
-            "WIDOW": 5,
+            "SURVIVING_SPOUSE": 5,
         }
         return pd.Series(filing_status).map(CODE_MAP)
 

--- a/tax_microdata_benchmarking/examination/results2.md
+++ b/tax_microdata_benchmarking/examination/results2.md
@@ -121,4 +121,6 @@ following Phase 2 estimates is Tax-Calculator 3.5.3 version.
 Comments on Phase 2 Data Results
 --------------------------------
 
-The phase 2 dataset, ...
+The above results for the phase 2 dataset, plus other data-quality
+issues, will be investigated in phase 3 as part of this project's
+continuous-improvement procedures.

--- a/tax_microdata_benchmarking/examination/results2.md
+++ b/tax_microdata_benchmarking/examination/results2.md
@@ -16,7 +16,7 @@ in subsequent phases.
 For more on the source of the federal agency estimates and on how the
 model-plus-dataset estimates are generated, see the [examination
 methods](./methods.md) document.  The model used to generate the
-following Phase 2 estimates is Tax-Calculator 3.5.1 version.
+following Phase 2 estimates is Tax-Calculator 3.5.3 version.
 
 <br>
 
@@ -25,7 +25,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | CY23 Amount | CY26 Amount | Estimate Source |
 | ---:   | ---:   | :---   |
 | 1580.0 | 1829.9 | CBO    |
-|    ??? |    ??? | Tax-Calculator + phase 2 dataset |
+| 1602.9 | 1890.8 | Tax-Calculator + phase 2 dataset |
 | 1489.3 | 1711.0 | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -35,7 +35,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | CY23 Amount | CY26 Amount | Estimate Source |
 | ---:   | ---:   | :---   |
 | 2512.3 | 2849.4 | CBO    |
-|    ??? |    ??? | Tax-Calculator + phase 2 dataset |
+| 1910.2 | 2556.7 | Tax-Calculator + phase 2 dataset |
 | 2247.8 | 2742.1 | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -46,7 +46,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | ---:   | ---:   | :---   |
 | 122.1  | 57.6   | JCT    |
 | 108.6  | 55.7   | TSY    |
-|   ???  |  ???   | Tax-Calculator + phase 2 dataset |
+| 135.9  | 47.3   | Tax-Calculator + phase 2 dataset |
 | 126.2  | 43.1   | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -57,7 +57,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | ---:   | ---:   | :---   |
 | 71.9   | 78.0   | JCT    |
 | 63.6   | 71.2   | TSY    |
-|  ???   |  ???   | Tax-Calculator + phase 2 dataset |
+| 70.7   | 77.5   | Tax-Calculator + phase 2 dataset |
 | 73.5   | 82.0   | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -68,7 +68,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | ---:   | ---:   | :---   |
 | 45.9   | 56.4   | JCT    |
 | 31.4   | 38.4   | TSY    |
-|  ???   |  ???   | Tax-Calculator + phase 2 dataset |
+| 13.4   | 22.3   | Tax-Calculator + phase 2 dataset |
 | 62.7   | 89.5   | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -79,7 +79,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | ---:   | ---:   | :---   |
 | -56.5  | -53.8  | JCT    |
 |  ----  |  ----  | TSY    |
-|   ???  |  ???   | Tax-Calculator + phase 2 dataset |
+| -54.9  | -54.5  | Tax-Calculator + phase 2 dataset |
 | -55.8  | -52.1  | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -90,7 +90,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | ---:   | ---:   | :---   |
 | 259.3  | 239.8  | JCT    |
 | 153.9  | 182.4  | TSY    |
-|   ???  | ???    | Tax-Calculator + phase 2 dataset |
+| 236.5  | 261.2  | Tax-Calculator + phase 2 dataset |
 | 217.7  | 223.6  | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -101,7 +101,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | ---:   | ---:   | :---   |
 | 56.2   |  0.0   | JCT    |
 | 50.4   |  0.0   | TSY    |
-|  ???   |  ???   | Tax-Calculator + phase 2 dataset |
+| 59.9   |  0.0   | Tax-Calculator + phase 2 dataset |
 | 19.3   |  0.0   | Tax-Calculator + taxdata dataset |
 
 <br>
@@ -112,7 +112,7 @@ following Phase 2 estimates is Tax-Calculator 3.5.1 version.
 | ---:   | ---:   | :---   |
 |  21.2  | 151.3  | JCT    |
 |  26.5  | 149.0  | TSY    |
-|   ???  | ???    | Tax-Calculator + phase 2 dataset |
+|  13.1  | 137.2  | Tax-Calculator + phase 2 dataset |
 |  29.4  | 185.5  | Tax-Calculator + taxdata dataset |
 
 <br>

--- a/tax_microdata_benchmarking/examination/taxcalculator/xb23-23.res-expect
+++ b/tax_microdata_benchmarking/examination/taxcalculator/xb23-23.res-expect
@@ -1,0 +1,27 @@
+Weighted Tax Reform Totals by Baseline Expanded-Income Decile
+    Returns    ExpInc    IncTax    PayTax     LSTax    AllTax
+ A   209.71   17080.4    1910.2    1602.9       0.0    3513.1
+
+==> xb23-23-#-cgqd-#-tab.text <==
+ A   209.71   17080.4     236.5       0.0       0.0     236.5
+
+==> xb23-23-#-clp-#-tab.text <==
+ A   209.71   17080.4       0.0       0.0       0.0       0.0
+
+==> xb23-23-#-ctc-#-tab.text <==
+ A   209.71   17080.4     135.9       0.0       0.0     135.9
+
+==> xb23-23-#-eitc-#-tab.text <==
+ A   209.71   17080.4      70.7       0.0       0.0      70.7
+
+==> xb23-23-#-niit-#-tab.text <==
+ A   209.71   17080.4     -54.9       0.0       0.0     -54.9
+
+==> xb23-23-#-qbid-#-tab.text <==
+ A   209.71   17080.4      59.9       0.0       0.0      59.9
+
+==> xb23-23-#-salt-#-tab.text <==
+ A   209.71   17080.4      13.1       0.0       0.0      13.1
+
+==> xb23-23-#-ssben-#-tab.text <==
+ A   209.71   17080.4      13.4       0.0       0.0      13.4

--- a/tax_microdata_benchmarking/examination/taxcalculator/xb26-26.res-expect
+++ b/tax_microdata_benchmarking/examination/taxcalculator/xb26-26.res-expect
@@ -1,0 +1,27 @@
+Weighted Tax Reform Totals by Baseline Expanded-Income Decile
+    Returns    ExpInc    IncTax    PayTax     LSTax    AllTax
+ A   215.29   19449.8    2556.7    1890.8       0.0    4447.4
+
+==> xb26-26-#-cgqd-#-tab.text <==
+ A   215.29   19449.8     261.2       0.0       0.0     261.2
+
+==> xb26-26-#-clp-#-tab.text <==
+ A   215.29   19449.8       0.0       0.0       0.0       0.0
+
+==> xb26-26-#-ctc-#-tab.text <==
+ A   215.29   19449.8      47.3       0.0       0.0      47.3
+
+==> xb26-26-#-eitc-#-tab.text <==
+ A   215.29   19449.8      77.5       0.0       0.0      77.5
+
+==> xb26-26-#-niit-#-tab.text <==
+ A   215.29   19449.8     -54.5       0.0       0.0     -54.5
+
+==> xb26-26-#-qbid-#-tab.text <==
+ A   215.29   19449.8       0.0       0.0       0.0       0.0
+
+==> xb26-26-#-salt-#-tab.text <==
+ A   215.29   19449.8     137.2       0.0       0.0     137.2
+
+==> xb26-26-#-ssben-#-tab.text <==
+ A   215.29   19449.8      22.3       0.0       0.0      22.3


### PR DESCRIPTION
This PR adds tax revenue and tax expenditure estimates generated by Tax-Calculator (version 3.5.3) using Phase2 (v7) input datasets for 2023 and for 2026.
