### PR TITLE
Add test_create_taxcalc_tmd_file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 **/*.pyc
 **/*.csv.zip
 **/*.csv.gz
-!tax_microdata_benchmarking/tmd_exact_2021_weights.csv.gz
 !tax_microdata_benchmarking/tmd_weights.csv.gz
 **/*.egg-info
 # Tensorboard

--- a/tax_microdata_benchmarking/create_taxcalc_sampling_weights.py
+++ b/tax_microdata_benchmarking/create_taxcalc_sampling_weights.py
@@ -14,12 +14,12 @@ POPFILE = "cbo_population_forecast.yaml"
 WGTFILE = "tmd_weights.csv.gz"
 
 
-def create_weights_file():
+def create_weights_file(pop_file=POPFILE):
     """
     Create Tax-Calculator-style weights file for FIRST_YEAR through LAST_YEAR.
     """
     # get population forecast
-    with open(POPFILE, "r", encoding="utf-8") as pfile:
+    with open(pop_file, "r", encoding="utf-8") as pfile:
         pop = yaml.safe_load(pfile.read())
 
     # get FIRST_YEAR weights from VARFILE

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -200,6 +200,9 @@ def test_2023_tax_expenditures():
 
 
 def test_create_taxcalc_files():
+    if test_mode != "full":
+        return
+
     from tax_microdata_benchmarking.create_taxcalc_input_variables import (
         create_variable_file,
     )
@@ -210,8 +213,11 @@ def test_create_taxcalc_files():
         create_factors_file,
     )
 
+    popfile = os.path.join(
+        '..', 'tax_microdata_benchmarking', 'cbo_population_forecast.yaml'
+    )
     create_variable_file()
-    create_weights_file()
+    create_weights_file(popfile)
     create_factors_file()
 
 

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -201,14 +201,15 @@ def test_2023_tax_expenditures():
 
 def test_create_taxcalc_files():
     from tax_microdata_benchmarking.create_taxcalc_input_variables import (
-        create_variable_file
+        create_variable_file,
     )
     from tax_microdata_benchmarking.create_taxcalc_sampling_weights import (
-        create_weights_file
+        create_weights_file,
     )
     from tax_microdata_benchmarking.create_taxcalc_growth_factors import (
-        create_factors_file
+        create_factors_file,
     )
+
     create_variable_file()
     create_weights_file()
     create_factors_file()

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -214,7 +214,7 @@ def test_create_taxcalc_files():
     )
 
     popfile = os.path.join(
-        '..', 'tax_microdata_benchmarking', 'cbo_population_forecast.yaml'
+        "..", "tax_microdata_benchmarking", "cbo_population_forecast.yaml"
     )
     create_variable_file()
     create_weights_file(popfile)

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -214,10 +214,11 @@ def test_create_taxcalc_files():
     )
 
     popfile = os.join(
-        FOLDER.parent,
+        Path(__file__).parent,
         "tax_microdata_benchmarking",
         "cbo_population_forecast.yaml",
     )
+    assert os.is_file(popfile)
     create_variable_file()
     create_weights_file(popfile)
     create_factors_file()

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -196,7 +196,25 @@ def test_2023_tax_expenditures():
         ), f"Tax Expenditure for {name} is ${df['AllTax'][i]}bn compared to Tax-Data's ${taxdata_exp_results[i]}bn (relative error {rel_error:.1%})"
 
 
-# Adding explicit tests for unemployment compensation and medical expenses.
+# Add test of use of the three create_taxcalc_*.py scripts:
+
+
+def test_create_taxcalc_files():
+    from tax_microdata_benchmarking.create_taxcalc_input_variables import (
+        create_variable_file
+    )
+    from tax_microdata_benchmarking.create_taxcalc_sampling_weights import (
+        create_weights_file
+    )
+    from tax_microdata_benchmarking.create_taxcalc_growth_factors import (
+        create_factors_file
+    )
+    create_variable_file()
+    create_weights_file()
+    create_factors_file()
+
+
+# Adding explicit tests for unemployment compensation and medical expenses:
 
 
 @pytest.mark.dependency(depends=["test_2021_flat_file_builds"])

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -196,31 +196,20 @@ def test_2023_tax_expenditures():
         ), f"Tax Expenditure for {name} is ${df['AllTax'][i]}bn compared to Tax-Data's ${taxdata_exp_results[i]}bn (relative error {rel_error:.1%})"
 
 
-# Add test of use of the three create_taxcalc_*.py scripts:
+# Add test of create_taxcalc_input_variable's create_variable_file function
+# that checks the consistency of initial_pt_w2_wages_scale argument of the
+# create_variable_file function:
 
 
-def test_create_taxcalc_files():
+def test_create_taxcalc_tmd_file():
     if test_mode != "full":
         return
 
     from tax_microdata_benchmarking.create_taxcalc_input_variables import (
         create_variable_file,
     )
-    from tax_microdata_benchmarking.create_taxcalc_sampling_weights import (
-        create_weights_file,
-    )
-    from tax_microdata_benchmarking.create_taxcalc_growth_factors import (
-        create_factors_file,
-    )
 
-    popfile = os.path.join(
-        FOLDER.parent,
-        "tax_microdata_benchmarking",
-        "cbo_population_forecast.yaml",
-    )
-    create_variable_file()
-    create_weights_file(popfile)
-    create_factors_file()
+    create_variable_file(write_file=False)
 
 
 # Adding explicit tests for unemployment compensation and medical expenses:

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -213,8 +213,10 @@ def test_create_taxcalc_files():
         create_factors_file,
     )
 
-    popfile = os.path.join(
-        "..", "tax_microdata_benchmarking", "cbo_population_forecast.yaml"
+    popfile = os.join(
+        FOLDER.parent,
+        "tax_microdata_benchmarking",
+        "cbo_population_forecast.yaml",
     )
     create_variable_file()
     create_weights_file(popfile)

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -213,12 +213,11 @@ def test_create_taxcalc_files():
         create_factors_file,
     )
 
-    popfile = os.join(
-        Path(__file__).parent,
+    popfile = os.path.join(
+        FOLDER.parent,
         "tax_microdata_benchmarking",
         "cbo_population_forecast.yaml",
     )
-    assert os.is_file(popfile)
     create_variable_file()
     create_weights_file(popfile)
     create_factors_file()


### PR DESCRIPTION
Add test of creating the `tmd.csv` file and whether or not the calibrated pass-through W-2 wages scale parameter value is consistent with the value used in the reweighting process.