### PR TITLE
Require taxcalc>=3.6 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,9 +5,8 @@ setup(
     version="0.1.0",
     packages=find_packages(),
     install_requires=[
-        "policyengine_us>=0.744",
-        "taxcalc>=3.5.0",
-        "paramtools==0.18.1",
+        "policyengine_us>=0.770",
+        "taxcalc>=3.6.0",
         "pytest",
         "black>=24.4.2",
     ],


### PR DESCRIPTION
Require newest version of Tax-Calcuator that includes `tmd_weights.csv.gz` and `growfactors.csv` extending out through 2074.