### PR TITLE
Update setup.py to require taxcalc 4.0.0+

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(),
     install_requires=[
         "policyengine_us>=0.770",
-        "taxcalc>=3.6.0",
+        "taxcalc>=4.0.0",
         "pytest",
         "black>=24.4.2",
         "torch",


### PR DESCRIPTION
Among other things Tax-Calculator 4.0 allows use of custom growfactors CSV files.
