### PR TITLE
Revise create_taxcalc_growth_factors.py to generate a tmd_growfactors.csv file

### DIFF
--- a/tax_microdata_benchmarking/create_taxcalc_growth_factors.py
+++ b/tax_microdata_benchmarking/create_taxcalc_growth_factors.py
@@ -1,5 +1,5 @@
 """
-Construct growfactors.csv, a Tax-Calculator-style GrowFactors file that
+Construct tmd_growfactors.csv, a Tax-Calculator-style GrowFactors file that
 extends through LAST_YEAR from the puf_growfactors.csv file, which is a
 copy of the most recent growfactors.csv file in the Tax-Calculator repository.
 """
@@ -7,9 +7,10 @@ copy of the most recent growfactors.csv file in the Tax-Calculator repository.
 import pandas as pd
 from tax_microdata_benchmarking.storage import STORAGE_FOLDER
 
+FIRST_YEAR = 2021
 LAST_YEAR = 2074
 PGFFILE = STORAGE_FOLDER / "input" / "puf_growfactors.csv"
-TGFFILE = STORAGE_FOLDER / "output" / "growfactors.csv"
+TGFFILE = STORAGE_FOLDER / "output" / "tmd_growfactors.csv"
 
 
 def create_factors_file():
@@ -18,7 +19,15 @@ def create_factors_file():
     """
     # read PUF-factors from PGFFILE
     gfdf = pd.read_csv(PGFFILE)
+    first_puf_year = gfdf.YEAR.iat[0]
     last_puf_year = gfdf.YEAR.iat[-1]
+
+    # drop gfdf rows before FIRST_YEAR
+    drop_row_index_list = range(0, FIRST_YEAR - first_puf_year)
+    gfdf.drop(drop_row_index_list, inplace=True)
+
+    # set all FIRST_YEAR growfactors to one
+    gfdf.iloc[0, 1:] = 1.0
 
     # add rows thru LAST_YEAR by copying values for last year in PUF file
     if LAST_YEAR > last_puf_year:

--- a/tax_microdata_benchmarking/create_taxcalc_growth_factors.py
+++ b/tax_microdata_benchmarking/create_taxcalc_growth_factors.py
@@ -1,7 +1,6 @@
 """
 Construct tmd_growfactors.csv, a Tax-Calculator-style GrowFactors file that
-extends through LAST_YEAR from the puf_growfactors.csv file, which is a
-copy of the most recent growfactors.csv file in the Tax-Calculator repository.
+covers the years from FIRST_YEAR through LAST_YEAR.
 """
 
 import pandas as pd

--- a/tax_microdata_benchmarking/examination/taxcalculator/tmd-26.res-expect
+++ b/tax_microdata_benchmarking/examination/taxcalculator/tmd-26.res-expect
@@ -1,6 +1,6 @@
 Weighted Tax Reform Totals by Baseline Expanded-Income Decile
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax
- A   229.65   22953.1    2915.6    1874.8       0.0    4790.4
+ A   229.65   22953.1    2915.6    1874.8       0.0    4790.5
 
 ==> tmd-26-#-cgqd-#-tab.text <==
  A   229.65   22953.1     268.6       0.0       0.0     268.6


### PR DESCRIPTION
Update the `create_taxcalc_growth_factors.py` script to generate a tmd-specific growfactors file.  And use the newly revised Tax-Calculator (that uses the new tmd-specific growfactors file) to redo the 2023 and 2026 examination runs as a check that nothing of significance changes.