### PR TITLE
Fix setup.py to include correct required policyengine-us version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ setup(
     version="0.1.0",
     packages=find_packages(),
     install_requires=[
-        "policyengine_us>=0.770",
+        "policyengine_us>=0.794",
         "taxcalc>=4.0.0",
         "pytest",
         "black>=24.4.2",


### PR DESCRIPTION
Use of `policyengine-us` packages consistent with the old `setup.py` version number cause errors after the merge of pull request #90 (which forgot to do this update of `setup.py`).

An example of the errors encountered when using older `policyengine-us` packages is [here](https://github.com/PSLmodels/tax-microdata-benchmarking/issues/93#issuecomment-2178685213).   That error mentions a missing Tax-Calculator `estate_income` variable that was added just a few days ago (2024-06-18) in `policyengine-us` version 0.790 via [Policyengine-US PR 4655](https://github.com/PolicyEngine/policyengine-us/pull/4655).