### PR TITLE
Restore create_taxcalc_input_variables.py code deleted in a recent merge

### DIFF
--- a/tax_microdata_benchmarking/create_taxcalc_input_variables.py
+++ b/tax_microdata_benchmarking/create_taxcalc_input_variables.py
@@ -39,7 +39,21 @@ def create_variable_file(write_file=True):
         original_weights = vdf.s006_original.copy()
     else:
         original_weights = vdf.s006.copy()
-    # vdf.drop(columns=rec.IGNORED_VARS, inplace=True)
+    if write_file:
+        # save a copy containing both input and output variables
+        fname = STORAGE_FOLDER / "output" / "tmd_2021.csv"
+        print(f"Writing PUF+CPS file... [{fname}]")
+        vdf.to_csv(fname, index=False)
+    # streamline dataframe so that it includes only input variables
+    rec = tc.Records(
+        data=vdf,
+        start_year=TAXYEAR,
+        gfactors=None,
+        weights=None,
+        adjust_ratios=None,
+        exact_calculations=True,
+    )
+    vdf.drop(columns=rec.IGNORED_VARS, inplace=True)
     # round all float variables to nearest integer except for weights
     vdf = vdf.astype(int)
     vdf.s006 = weights
@@ -47,14 +61,11 @@ def create_variable_file(write_file=True):
         vdf["s006_original"] = original_weights
     for var in ["e00200", "e00900", "e02100"]:
         vdf[var] = vdf[f"{var}p"] + vdf[f"{var}s"]
-    # write streamlined variables dataframe to CSV-formatted file
+    # write input-variables-only dataframe to CSV-formatted file
     if write_file:
-        tmd_csv_fname = STORAGE_FOLDER / "output" / "tmd.csv.gz"
-        print(f"Writing PUF+CPS file... [{tmd_csv_fname}]")
-        vdf.to_csv(tmd_csv_fname, index=False, float_format="%.2f")
-        vdf.to_csv(
-            STORAGE_FOLDER / "output" / "tmd_2021.csv", index=False
-        )  # Save an extra copy which doesn't take long to read.
+        fname = STORAGE_FOLDER / "output" / "tmd.csv.gz"
+        print(f"Writing PUF+CPS file... [{fname}]")
+        vdf.to_csv(fname, index=False, float_format="%.2f")
 
 
 if __name__ == "__main__":

--- a/tax_microdata_benchmarking/utils/soi_replication.py
+++ b/tax_microdata_benchmarking/utils/soi_replication.py
@@ -148,6 +148,8 @@ def tc_to_soi(puf, year):
         start_year=year,
         gfactors=None,
         weights=None,
+        adjust_ratios=None,
+        exact_calculations=True,
     )
     calculator = tc.Calculator(policy=policy, records=data)
     calculator.calc_all()

--- a/tax_microdata_benchmarking/utils/taxcalc_utils.py
+++ b/tax_microdata_benchmarking/utils/taxcalc_utils.py
@@ -78,6 +78,7 @@ def add_taxcalc_outputs(
         start_year=input_data_year,
         gfactors=growf,
         weights=wghts,
+        adjust_ratios=None,
         exact_calculations=True,
     )
     policy = tc.Policy()

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -74,10 +74,10 @@ variables_to_test = [
     if variable not in EXEMPTED_VARIABLES
 ]
 
-dataset_names_to_test = ["tmd"]
+dataset_names_to_test = ["tmd_2021"]
 
 datasets_to_test = [
-    pd.read_csv(STORAGE_FOLDER / "output" / f"{dataset}.csv.gz")
+    pd.read_csv(STORAGE_FOLDER / "output" / f"{dataset}.csv")
     for dataset in dataset_names_to_test
 ]
 
@@ -161,6 +161,7 @@ def test_no_negative_weights(flat_file):
     assert flat_file.s006.min() >= 0, "Negative weights found."
 
 
+@pytest.mark.qbid
 @pytest.mark.parametrize(
     "flat_file", datasets_to_test, ids=dataset_names_to_test
 )

--- a/tests/test_flat_file.py
+++ b/tests/test_flat_file.py
@@ -94,7 +94,7 @@ def test_variable_totals(variable, flat_file):
     if tc_variable_totals[variable] == 0:
         # If the taxdata file has a zero total, we'll assume the tested file is correct in the absence of better data.
         return
-    # 20% and more than 10bn off taxdata is a failure.
+    # 45% and more than $30bn off taxdata is a failure.
     assert (
         abs(total / tc_variable_totals[variable] - 1) < 0.45
         or abs(total / 1e9 - tc_variable_totals[variable] / 1e9) < 30
@@ -167,4 +167,4 @@ def test_no_negative_weights(flat_file):
 def test_qbided_close_to_soi(flat_file):
     assert (
         abs((flat_file.s006 * flat_file.qbided).sum() / 1e9 / 205.8 - 1) < 0.25
-    ), "QBIDED not within 1 percent of 205.8bn"
+    ), "QBIDED not within 25 percent of 205.8bn"


### PR DESCRIPTION
Add back code needed to prepare Tax-Calculator input file.
