### PR TITLE
Add examination alt_ctc_taxexp.py script

### DIFF
--- a/tax_microdata_benchmarking/examination/results3.md
+++ b/tax_microdata_benchmarking/examination/results3.md
@@ -41,7 +41,7 @@ merge of PR 2764 on 2024-07-04).
 | ---:   | ---:   | :---   |
 | 2512.3 | 2849.4 | CBO    |
 | 2371.4 | 2999.4 | Tax-Calculator + phase 3 dataset |
-| 2247.8 | 2742.1 | Tax-Calculator + taxdata dataset |
+| 2247.9 | 2742.2 | Tax-Calculator + taxdata dataset |
 
 <br>
 
@@ -52,7 +52,7 @@ merge of PR 2764 on 2024-07-04).
 | 122.1  | 57.6   | JCT    |
 | 108.6  | 55.7   | TSY    |
 |  73.5  | 26.7   | Tax-Calculator + phase 3 dataset |
-| 126.2  | 43.1   | Tax-Calculator + taxdata dataset |
+| 126.3  | 43.1   | Tax-Calculator + taxdata dataset |
 
 <br>
 

--- a/tax_microdata_benchmarking/examination/taxcalculator/alt_ctc_taxexp.py
+++ b/tax_microdata_benchmarking/examination/taxcalculator/alt_ctc_taxexp.py
@@ -1,0 +1,83 @@
+"""
+Tabulate alternative CTC tax-expenditure estimate.
+"""
+
+import os
+import sys
+import argparse
+import pandas as pd
+
+
+def main():
+    """
+    High-level script logic.
+    """
+    # parse command-line arguments
+    usage_str = "python alt_ctc_taxexp.py INPUT YEAR [--help]"
+    parser = argparse.ArgumentParser(
+        prog="", usage=usage_str, description=__doc__
+    )
+    parser.add_argument(
+        "INPUT",
+        help="Name of CSV-formatted file containing the input dataset",
+        nargs="?",
+        default="",
+    )
+    parser.add_argument(
+        "YEAR",
+        help="Tax policy calendar year of tax-expenditure results",
+        type=int,
+        nargs="?",
+        default=0,
+    )
+    args = parser.parse_args()
+
+    # check command-line argument values
+    args_ok = True
+    if args.INPUT.endswith(".csv"):
+        sys.stderr.write(f"ERROR: {args.INPUT} ends with .csv\n")
+        args_ok = False
+    if args.YEAR not in [23, 26]:
+        sys.stderr.write(f"ERROR: YEAR {args.YEAR} is neither 23 nor 26\n")
+        args_ok = False
+    if not args_ok:
+        sys.stderr.write(f"USAGE: {usage_str}\n")
+        return 1
+
+    # construct baseline and tax-expenditure reform dump output file names
+    generic = f"{args.INPUT}-{args.YEAR}-#-xxx-#.csv"
+    bas_fname = generic.replace("xxx", "clp")
+    ref_fname = generic.replace("xxx", "ctc")
+    args_ok = True
+    if not os.path.isfile(bas_fname):
+        sys.stderr.write(f"ERROR: {bas_fname} file does not exist\n")
+        args_ok = False
+    if not os.path.isfile(ref_fname):
+        sys.stderr.write(f"ERROR: {ref_fname} file does not exist\n")
+        args_ok = False
+    if not args_ok:
+        sys.stderr.write(f"USAGE: {usage_str}\n")
+        return 1
+
+    # read base and reform .csv dump output files
+    bdf = pd.read_csv(bas_fname)
+    rdf = pd.read_csv(ref_fname)
+
+    # standard tax-expenditure tabulation using iitax
+    btax = (bdf.s006 * bdf.iitax).sum() * 1e-9
+    rtax = (rdf.s006 * rdf.iitax).sum() * 1e-9
+    std_te = rtax - btax
+    print(f"STD tax-expenditure($B)= {std_te:.3f}")
+
+    # alternative tax-expenditure tabulation using ctc_total
+    bctc = (bdf.s006 * bdf.ctc_total).sum() * 1e-9
+    rctc = (rdf.s006 * rdf.ctc_total).sum() * 1e-9
+    alt_te = bctc - rctc
+    print(f"ALT tax-expenditure($B)= {alt_te:.3f}")
+
+    # return no-error exit code
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tax_microdata_benchmarking/examination/taxcalculator/clp.dvars
+++ b/tax_microdata_benchmarking/examination/taxcalculator/clp.dvars
@@ -2,3 +2,6 @@ dwks43
 e00650
 p23250
 taxbc
+ctc_total
+iitax
+s006

--- a/tax_microdata_benchmarking/examination/taxcalculator/ctc.dvars
+++ b/tax_microdata_benchmarking/examination/taxcalculator/ctc.dvars
@@ -1,5 +1,2 @@
-c07220
-c11070
-codtc_limited
-odc
-ctc_new
+ctc_total
+ctc_refundable

--- a/tax_microdata_benchmarking/examination/taxcalculator/ctc.dvars
+++ b/tax_microdata_benchmarking/examination/taxcalculator/ctc.dvars
@@ -1,2 +1,3 @@
 ctc_total
-ctc_refundable
+iitax
+s006

--- a/tax_microdata_benchmarking/examination/taxcalculator/puf-23.res-expect
+++ b/tax_microdata_benchmarking/examination/taxcalculator/puf-23.res-expect
@@ -1,6 +1,6 @@
 Weighted Tax Reform Totals by Baseline Expanded-Income Decile
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax
- A   208.42   18638.0    2247.8    1489.3       0.0    3737.1
+ A   208.42   18638.0    2247.9    1489.3       0.0    3737.2
 
 ==> puf-23-#-cgqd-#-tab.text <==
  A   208.42   18638.0     217.7       0.0       0.0     217.7
@@ -9,7 +9,7 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile
  A   208.42   18638.0       0.0       0.0       0.0       0.0
 
 ==> puf-23-#-ctc-#-tab.text <==
- A   208.42   18638.0     126.2       0.0       0.0     126.2
+ A   208.42   18638.0     126.3       0.0       0.0     126.3
 
 ==> puf-23-#-eitc-#-tab.text <==
  A   208.42   18638.0      73.5       0.0       0.0      73.5

--- a/tax_microdata_benchmarking/examination/taxcalculator/puf-26.res-expect
+++ b/tax_microdata_benchmarking/examination/taxcalculator/puf-26.res-expect
@@ -1,6 +1,6 @@
 Weighted Tax Reform Totals by Baseline Expanded-Income Decile
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax
- A   216.75   21231.4    2742.1    1711.0       0.0    4453.1
+ A   216.75   21231.4    2742.2    1711.0       0.0    4453.1
 
 ==> puf-26-#-cgqd-#-tab.text <==
  A   216.75   21231.4     223.6       0.0       0.0     223.6

--- a/tax_microdata_benchmarking/examination/taxcalculator/runs.sh
+++ b/tax_microdata_benchmarking/examination/taxcalculator/runs.sh
@@ -63,6 +63,9 @@ echo CLP
 
 echo CTC
 ./execute.sh $1.csv 20$2 ctc
+if [[ -v QUIT ]]; then
+    exit 1
+fi
 
 echo EITC
 ./execute.sh $1.csv 20$2 eitc


### PR DESCRIPTION
Add `examination/taxcalculator/alt_ctc_taxexp.py` script that computes tax-expenditure under an alternative assumption.   There is only a very small difference between this alternative tax expenditure and the standard-assumption tax expenditure for the CTC.