### PR TITLE
Revise Imputation code to avoid numpy deprecation warning

### DIFF
--- a/tax_microdata_benchmarking/utils/imputation.py
+++ b/tax_microdata_benchmarking/utils/imputation.py
@@ -300,9 +300,7 @@ class ManyToOneImputation:
             a, 1, size=tree_predictions.shape[0]
         )
         x = np.apply_along_axis(
-            lambda x: np.percentile(
-                x[1:], x[0], interpolation="nearest"
-            ),  # Privacy??
+            lambda x: np.percentile(x[1:], x[0], method="nearest"),
             1,
             np.concatenate(
                 [


### PR DESCRIPTION
Responds in part to issue #135.

The remaining deprecation and performance warnings are in the `datasets/puf.py` and `datasets/uprate_puf.py` modules.