### PR TITLE
Add calculation of Tax-Calculator agi_bin variable

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -2,6 +2,8 @@
 Miscellaneous tests of tmd.csv variable weighted totals.
 """
 
+import numpy as np
+
 
 def test_no_negative_weights(tmd_variables):
     assert tmd_variables.s006.min() >= 0, "Negative weights found"
@@ -22,3 +24,9 @@ def test_population(tmd_variables):
     assert (
         abs(population / 1e6 / 334.18 - 1) < 0.01
     ), "Population not within 1% of 334.18 million"
+
+
+def test_agi_bin(tmd_variables):
+    bin = tmd_variables.agi_bin
+    assert np.min(bin) == 0, "Minimum value in agi_bin is not zero"
+    assert np.max(bin) == 6, "Maximum value in agi_bin is not six"

--- a/tmd/create_taxcalc_input_variables.py
+++ b/tmd/create_taxcalc_input_variables.py
@@ -2,6 +2,7 @@
 Construct tmd.csv, a Tax-Calculator-style input variable file for 2021.
 """
 
+import pandas as pd
 import taxcalc as tc
 from tmd.datasets.tmd import create_tmd_2021
 from tmd.imputation_assumptions import (
@@ -11,6 +12,7 @@ from tmd.imputation_assumptions import (
     W2_WAGES_SCALE,
     CPS_WEIGHTS_SCALE,
     REWEIGHT_DEVIATION_PENALTY,
+    SOI_ZIP_AGI_BINS,
 )
 from tmd.storage import STORAGE_FOLDER
 
@@ -33,6 +35,12 @@ def create_variable_file(write_file=True):
     vdf = create_tmd_2021()
     vdf.FLPDYR = TAXYEAR
     weights = vdf.s006.copy()
+    vdf.agi_bin = pd.cut(
+        vdf.c00100,
+        SOI_ZIP_AGI_BINS,
+        right=False,
+        labels=False,
+    )
     if write_file:
         # save a copy containing both input and output variables
         fname = STORAGE_FOLDER / "output" / "tmd_2021.csv"

--- a/tmd/imputation_assumptions.py
+++ b/tmd/imputation_assumptions.py
@@ -13,8 +13,21 @@ ITMDED_GROW_RATE = 0.02  # annual growth rate in itemized deduction amounts
 
 CPS_WEIGHTS_SCALE = 0.5806  # used to scale CPS-subsample population
 
+# parameters used in creation of national sampling weights:
 REWEIGHT_MULTIPLIER_MIN = 0.1
 REWEIGHT_MULTIPLIER_MAX = 10.0
 REWEIGHT_DEVIATION_PENALTY = 0.0
 # penalty value of 1.0 says "this is as important as everything else"
 # penalty value of 0.0 imposes no penalty
+
+# AGI bins used in weight creation for subnational areas:
+SOI_ZIP_AGI_BINS = [
+    -9e99,
+    1.0,
+    25e3,
+    50e3,
+    75e3,
+    100e3,
+    200e3,
+    9e99,
+]


### PR DESCRIPTION
The values of `agi_bin` will be used in the creation of subnational area sampling weights.