### PR TITLE
Remove calculation of agi_bin variable

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -24,9 +24,3 @@ def test_population(tmd_variables):
     assert (
         abs(population / 1e6 / 334.18 - 1) < 0.01
     ), "Population not within 1% of 334.18 million"
-
-
-def test_agi_bin(tmd_variables):
-    bin = tmd_variables.agi_bin
-    assert np.min(bin) == 0, "Minimum value in agi_bin is not zero"
-    assert np.max(bin) == 6, "Maximum value in agi_bin is not six"

--- a/tmd/create_taxcalc_input_variables.py
+++ b/tmd/create_taxcalc_input_variables.py
@@ -2,7 +2,6 @@
 Construct tmd.csv, a Tax-Calculator-style input variable file for 2021.
 """
 
-import pandas as pd
 import taxcalc as tc
 from tmd.datasets.tmd import create_tmd_2021
 from tmd.imputation_assumptions import (
@@ -12,7 +11,6 @@ from tmd.imputation_assumptions import (
     W2_WAGES_SCALE,
     CPS_WEIGHTS_SCALE,
     REWEIGHT_DEVIATION_PENALTY,
-    SOI_ZIP_AGI_BINS,
 )
 from tmd.storage import STORAGE_FOLDER
 
@@ -34,13 +32,8 @@ def create_variable_file(write_file=True):
     print(f"  ASSUMED CPS_WEIGHTS_SCALE = {CPS_WEIGHTS_SCALE:.5f}")
     vdf = create_tmd_2021()
     vdf.FLPDYR = TAXYEAR
+    vdf.agi_bin = 0
     weights = vdf.s006.copy()
-    vdf.agi_bin = pd.cut(
-        vdf.c00100,
-        SOI_ZIP_AGI_BINS,
-        right=False,
-        labels=False,
-    )
     if write_file:
         # save a copy containing both input and output variables
         fname = STORAGE_FOLDER / "output" / "tmd_2021.csv"

--- a/tmd/imputation_assumptions.py
+++ b/tmd/imputation_assumptions.py
@@ -19,15 +19,3 @@ REWEIGHT_MULTIPLIER_MAX = 10.0
 REWEIGHT_DEVIATION_PENALTY = 0.0
 # penalty value of 1.0 says "this is as important as everything else"
 # penalty value of 0.0 imposes no penalty
-
-# AGI bins used in weight creation for subnational areas:
-SOI_ZIP_AGI_BINS = [
-    -9e99,
-    1.0,
-    25e3,
-    50e3,
-    75e3,
-    100e3,
-    200e3,
-    9e99,
-]


### PR DESCRIPTION
Because of the multitude of AGI bin definitions used in different SOI sub-national data sources.

Fixes issue #183 in part.
