### PR TITLE
Solve for ratios of new weights to original weights, rather than directly solving for new weights

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -150,7 +150,7 @@ def create_area_weights_file(area: str, write_file: bool = True):
     # construct variable matrix and target array and weights_scale
     vdf = all_taxcalc_variables()
     variable_matrix, target_array, weights_scale = prepared_data(area, vdf)
-    wght = vdf.s006 * weights_scale
+    wght = np.array(vdf.s006 * weights_scale)
     num_weights = len(wght)
     num_targets = len(target_array)
     print(f"USING {area}_targets.csv FILE CONTAINING {num_targets} TARGETS")

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -157,13 +157,13 @@ def create_area_weights_file(area: str, write_file: bool = True):
     print(f"USING {area}_targets.csv FILE CONTAINING {num_targets} TARGETS")
     loss = loss_function_value(wght, variable_matrix, target_array)
     print(f"US_PROPORTIONALLY_SCALED_LOSS_FUNCTION_VALUE= {loss:.9e}")
-    
+
     density = np.count_nonzero(variable_matrix) / variable_matrix.size
     print(f"variable_matrix sparsity ratio = {(1.0 - density):.3f}")
-    
+
     # solve for ratio of unknown new weight (wghtx) to original weight (wght) such that
     # new weight minimizes sum of squared wghtx*var-target deviations
-    
+
     # lower and upper bounds for ratio of new to original weight
     lb = np.full(num_weights, 0.01)
     ub = np.full(num_weights, 10.0)
@@ -198,12 +198,25 @@ def create_area_weights_file(area: str, write_file: bool = True):
         wght_rchg = 2.0 * multiplier
         num_inc = ((wghtx / wght) > wght_rchg).sum()
         print(f"# units with post/pre weight ratio > {wght_rchg} is {num_inc}")
-    
+
     def formatted_print(numbers, format_spec=".3f"):
         formatted_numbers = (f"{num:{format_spec}}" for num in numbers)
         print(", ".join(formatted_numbers))
+
     if SHOW_QUANTILES:
-        qtiles = [0.0, 0.01, 0.05, 0.10, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 1.0]
+        qtiles = [
+            0.0,
+            0.01,
+            0.05,
+            0.10,
+            0.25,
+            0.5,
+            0.75,
+            0.90,
+            0.95,
+            0.99,
+            1.0,
+        ]
         print(f"quantiles of original and new weights, and ratio: ")
         print(f"quantiles: {qtiles}")
         wght_quantiles = np.quantile(wght, qtiles)
@@ -215,7 +228,7 @@ def create_area_weights_file(area: str, write_file: bool = True):
         formatted_print(wghtx_quantiles)
         print("ratio of new to original weights: ")
         formatted_print(ratio_quantiles)
-        
+
     loss = loss_function_value(wghtx, variable_matrix, target_array)
     print(f"AREA-OPTIMIZED_LOSS_FUNCTION_VALUE= {loss:.9e}")
 

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -164,7 +164,7 @@ def create_area_weights_file(area: str, write_file: bool = True):
     ub = np.full(num_weights, np.inf)
     time0 = time.time()
     res = lsq_linear(
-        variable_matrix.T,
+        (variable_matrix * wght[:, np.newaxis]).T,
         target_array,
         bounds=(lb, ub),
         method="bvls",

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -203,7 +203,7 @@ def create_area_weights_file(area: str, write_file: bool = True):
         formatted_numbers = (f"{num:{format_spec}}" for num in numbers)
         print(", ".join(formatted_numbers))
     if SHOW_QUANTILES:
-        qtiles = [0.0, 0.10, 0.25, 0.5, 0.75, 0.90, 1.0]
+        qtiles = [0.0, 0.01, 0.05, 0.10, 0.25, 0.5, 0.75, 0.90, 0.95, 0.99, 1.0]
         print(f"quantiles of original and new weights, and ratio: ")
         print(f"quantiles: {qtiles}")
         wght_quantiles = np.quantile(wght, qtiles)

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -161,8 +161,8 @@ def create_area_weights_file(area: str, write_file: bool = True):
     density = np.count_nonzero(variable_matrix) / variable_matrix.size
     print(f"variable_matrix sparsity ratio = {(1.0 - density):.3f}")
     
-    # solve for ratio of new weight to original weight such that
-    # new weight (wght) minimizes sum of squared wght*var-target deviations    
+    # solve for ratio of unknown new weight (wghtx) to original weight (wght) such that
+    # new weight minimizes sum of squared wghtx*var-target deviations
     
     # lower and upper bounds for ratio of new to original weight
     lb = np.full(num_weights, 0.01)

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -184,7 +184,7 @@ def create_area_weights_file(area: str, write_file: bool = True):
     print(res_summary)
     if OPTIMIZE_RESULTS:
         print(">>> scipy.lsq_linear full results:\n", res)
-    wghtx = res.x
+    wghtx = res.x * wght
     num_neg = (wghtx < 0).sum()
     assert num_neg == 0, f"num_negative_weights= {num_neg}"
     print(f"# units in total is {num_weights}")

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -27,7 +27,7 @@ POPFILE_PATH = STORAGE_FOLDER / "input" / "cbo_population_forecast.yaml"
 DUMP_LOSS_FUNCTION_VALUE_COMPONENTS = True
 OPTIMIZE_FTOL = 1e-10
 OPTIMIZE_MAXITER = 900
-OPTIMIZE_VERBOSE = 0  # set to zero for no iteration information
+OPTIMIZE_VERBOSE = 2  # set to zero for no iteration information
 OPTIMIZE_RESULTS = False
 
 
@@ -156,12 +156,16 @@ def create_area_weights_file(area: str, write_file: bool = True):
     print(f"USING {area}_targets.csv FILE CONTAINING {num_targets} TARGETS")
     loss = loss_function_value(wght, variable_matrix, target_array)
     print(f"US_PROPORTIONALLY_SCALED_LOSS_FUNCTION_VALUE= {loss:.9e}")
-
-    # find wght that minimizes sum of squared wght*var-target deviations
+    
     density = np.count_nonzero(variable_matrix) / variable_matrix.size
     print(f"variable_matrix sparsity ratio = {(1.0 - density):.3f}")
-    lb = np.zeros(num_weights)
-    ub = np.full(num_weights, np.inf)
+    
+    # solve for ratio of new weight to original weight such that
+    # new weight (wght) minimizes sum of squared wght*var-target deviations    
+    
+    # lower and upper bounds for ratio of new to original weight
+    lb = np.full(num_weights, 0.01)
+    ub = np.full(num_weights, 100.0)
     time0 = time.time()
     res = lsq_linear(
         (variable_matrix * wght[:, np.newaxis]).T,


### PR DESCRIPTION
This change addresses two challenges I was finding with `lsq_linear`: (1) the new weights sometimes appeared implausibly large, e.g., thousands of times as large as the original, and (2) my efforts to constrain weights by setting upper bounds on new weights were making the problem difficult for `lsq_linear` to solve, taking thousands of iterations and several minutes and still leading to large differences from targets, whereas problems without upper bounds were solving in a dozen iterations and less than a second.

It is common in reweighting efforts to solve for the ratio of new weights to original weights, rather than solving for new weights directly (even though in concept they can lead to the same result) for at least two reasons: (1) many reweighting efforts (e.g., JCT and taxdata) seek to minimize changes in weights and thus penalize weight changes by penalizing the ratio of new to original weights, which makes sense for national efforts although it makes less sense when constructing subnational files from a national file, and (2) the problem often seems more stable, numerically, when the x variable being solved for is centered near 1 (a ratio), rather than ranging from close to zero to possibly many thousands (a weight).

This PR:

- Changes the problem so that `lsq_linear` solves for the ratio rather than the new weight. It achieves this by multiplying the columns of the coefficient matrix (`variable_matrix.T` -- the A matrix in Ax = b nomenclature) by the original weight (`wght`) before transposing. (The A matrix passed to `lsq_linear` is `(variable_matrix * wght[:, np.newaxis]).T`) Thus, the x being solved for will be the ratio of the new weight to the original. 
- Changes the lower and upper bound calculations to be bounds on the ratio, and sets them, for discussion purposes, at 0.01 and 10.0, but that can be changed. What those bounds should be depends, I suppose, on how much we think the distribution of taxpayers in a subnational area can plausibly differ from the national average. I am concerned that if we don't constrain these changes, and are only trying to hit a few handfuls of targets, that allowing large changes in weights will lead to large unintended consequences for variables we don't (and cannot practically) target.
- Adds optional reporting on quantiles of original weights, new weights, and the resulting ratios.

In examining the results of this PR, in comparison to attempting to set bounds on new weights directly, I have found that:

- The ratio approach appears to improve the numerical qualities of the problem substantially, so that `lsq_linear` hits targets exactly even with sharp limits on weight changes, whereas it cannot do that when solving for new weights. 
- It solves these problems in a handful of iterations whereas with direct limits on weights it was taking thousands of iterations.
- The ratio of new to original weights seems to stay closer to 1 than it does when solving for new weights directly, even when not imposing upper bounds on the ratio.

Thus, preliminary results are attractive. I think as we move from hypothetical problems to real-world problems, we will have to keep our options open. We will undoubtedly encounter new issues and we may have reason to revisit the question of whether to solve for weights or ratios, and the question of whether to use a dedicated least-squares solver such or `lsq_linear` or a more-general solver such as `L-BFGS-B`.