### PR TITLE
Add descriptive statistics on initial weights to create_area_weights.py

### DIFF
--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -11,4 +11,3 @@ def test_area_bb():
     """
     rmse = create_area_weights_file("bb", write_file=False)
     assert rmse < 1e-4
-    assert 1 == 2, "SHOWING STDOUT RESULTS"

--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -11,4 +11,4 @@ def test_area_bb():
     """
     rmse = create_area_weights_file("bb", write_file=False)
     assert rmse < 1e-4
-    assert 1 == 2, "TO SHOW STDOUT RESULTS"
+    assert 1 == 2, "SHOWING STDOUT RESULTS"

--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -10,4 +10,5 @@ def test_area_bb():
     Optimize national weights using the faux bb area targets.
     """
     rmse = create_area_weights_file("bb", write_file=False)
-    assert rmse < 1e-3
+    assert rmse < 1e-4
+    assert 1 == 2, "TO SHOW STDOUT RESULTS"

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -277,6 +277,11 @@ def create_area_weights_file(area: str, write_file: bool = True):
     vdf = all_taxcalc_variables()
     target_matrix, target_array, weights_scale = prepared_data(area, vdf)
     wght_us = np.array(vdf.s006 * weights_scale)
+    print("INITIAL WEIGHTS STATISTICS:")
+    print(f"weights_scale= {weights_scale:e}")
+    wdf = pd.DataFrame({"s006": vdf.s006, "wght_us": wght_us})
+    print(wdf.describe())
+    del wdf
     num_weights = len(wght_us)
     num_targets = len(target_array)
     print(f"USING {area}_targets.csv FILE CONTAINING {num_targets} TARGETS")


### PR DESCRIPTION
The additional statistics (on `s006` and `wght_us`) show the distribution of the national weights that are the starting point of the `create_area_weights.py` logic.