### PR TITLE
Add areas/make_all.py tool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ clean:
 	rm -f tmd/storage/output/*
 
 tmd/storage/output/tmd.csv.gz: \
+  setup.py \
   tmd/imputation_assumptions.py \
   tmd/datasets/tmd.py \
   tmd/datasets/puf.py \

--- a/tests/test_area_make.py
+++ b/tests/test_area_make.py
@@ -1,0 +1,30 @@
+"""
+Tests of tmd/areas/create_area_weights.py script.
+"""
+
+import sys
+from difflib import context_diff
+import pytest
+from tmd.areas import AREAS_FOLDER
+from tmd.areas.make_all.py import make_all_areas
+
+
+@pytest.skip
+def test_area_make():
+    """
+    Optimize national weights for faux bb area using the faux bb area targets.
+    """
+    # write area/weights/bb_tmd_weights.csv.gz and area/weights/bb.log files
+    create_area_weights_file("bb", write_file=True)
+    # compare area/weights/bb.log file with area/weights/bb.log-expect file
+    wpath = AREAS_FOLDER / "weights"
+    with open(wpath / "bb.log", "r", encoding="utf-8") as afile:
+        act = afile.readlines()
+    with open(wpath / "bb.log-expect", "r", encoding="utf-8") as efile:
+        exp = efile.readlines()
+    diffs = list(
+        context_diff(act, exp, fromfile="ACTUAL", tofile="EXPECT", n=0)
+    )
+    if len(diffs) > 0:
+        sys.stdout.writelines(diffs)
+        raise ValueError("ACT vs EXP differences for area/weights/bb.log")

--- a/tests/test_area_make.py
+++ b/tests/test_area_make.py
@@ -9,7 +9,7 @@ from tmd.areas import AREAS_FOLDER
 from tmd.areas.make_all import make_all_areas
 
 
-# @pytest.mark.skip
+@pytest.mark.skip
 def test_area_make():
     """
     Make area weights for faux bb area using the faux bb area targets.

--- a/tests/test_area_make.py
+++ b/tests/test_area_make.py
@@ -9,13 +9,12 @@ from tmd.areas import AREAS_FOLDER
 from tmd.areas.make_all import make_all_areas
 
 
-@pytest.skip
+# @pytest.mark.skip
 def test_area_make():
     """
-    Optimize national weights for faux bb area using the faux bb area targets.
+    Make area weights for faux bb area using the faux bb area targets.
     """
-    # write area/weights/bb_tmd_weights.csv.gz and area/weights/bb.log files
-    create_area_weights_file("bb", write_file=True)
+    make_all_areas(only_list=["bb"])
     # compare area/weights/bb.log file with area/weights/bb.log-expect file
     wpath = AREAS_FOLDER / "weights"
     with open(wpath / "bb.log", "r", encoding="utf-8") as afile:

--- a/tests/test_area_make.py
+++ b/tests/test_area_make.py
@@ -6,7 +6,7 @@ import sys
 from difflib import context_diff
 import pytest
 from tmd.areas import AREAS_FOLDER
-from tmd.areas.make_all.py import make_all_areas
+from tmd.areas.make_all import make_all_areas
 
 
 @pytest.skip

--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -23,7 +23,7 @@ def test_area_bb():
     with open(wpath / "bb.log-expect", "r", encoding="utf-8") as efile:
         exp = efile.readlines()
     diffs = list(
-        context_diff(act, exp, fromfile='ACTUAL', tofile='EXPECT', n=0)
+        context_diff(act, exp, fromfile="ACTUAL", tofile="EXPECT", n=0)
     )
     if len(diffs) > 0:
         sys.stdout.writelines(diffs)

--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -2,12 +2,29 @@
 Tests of tmd/areas/create_area_weights.py script.
 """
 
+import sys
+from difflib import context_diff
+import pytest
+from tmd.areas import AREAS_FOLDER
 from tmd.areas.create_area_weights import create_area_weights_file
 
 
+# @pytest.skip
 def test_area_bb():
     """
-    Optimize national weights using the faux bb area targets.
+    Optimize national weights for faux bb area using the faux bb area targets.
     """
-    rmse = create_area_weights_file("bb", write_file=False)
-    assert rmse < 1e-4
+    # write area/weights/bb_tmd_weights.csv.gz and area/weights/bb.log files
+    create_area_weights_file("bb", write_file=True)
+    # compare area/weights/bb.log file with area/weights/bb.log-expect file
+    wpath = AREAS_FOLDER / "weights"
+    with open(wpath / "bb.log", "r", encoding="utf-8") as afile:
+        act = afile.readlines()
+    with open(wpath / "bb.log-expect", "r", encoding="utf-8") as efile:
+        exp = efile.readlines()
+    diffs = list(
+        context_diff(act, exp, fromfile='ACTUAL', tofile='EXPECT', n=0)
+    )
+    if len(diffs) > 0:
+        sys.stdout.writelines(diffs)
+        raise ValueError("ACT vs EXP differences for area/weights/bb.log")

--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -2,29 +2,12 @@
 Tests of tmd/areas/create_area_weights.py script.
 """
 
-import sys
-from difflib import context_diff
-import pytest
-from tmd.areas import AREAS_FOLDER
 from tmd.areas.create_area_weights import create_area_weights_file
 
 
-# @pytest.skip
 def test_area_bb():
     """
     Optimize national weights for faux bb area using the faux bb area targets.
     """
-    # write area/weights/bb_tmd_weights.csv.gz and area/weights/bb.log files
-    create_area_weights_file("bb", write_file=True)
-    # compare area/weights/bb.log file with area/weights/bb.log-expect file
-    wpath = AREAS_FOLDER / "weights"
-    with open(wpath / "bb.log", "r", encoding="utf-8") as afile:
-        act = afile.readlines()
-    with open(wpath / "bb.log-expect", "r", encoding="utf-8") as efile:
-        exp = efile.readlines()
-    diffs = list(
-        context_diff(act, exp, fromfile="ACTUAL", tofile="EXPECT", n=0)
-    )
-    if len(diffs) > 0:
-        sys.stdout.writelines(diffs)
-        raise ValueError("ACT vs EXP differences for area/weights/bb.log")
+    rmse = create_area_weights_file("bb", write_file=False)
+    assert rmse < 1e-4

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -407,7 +407,7 @@ def create_area_weights_file(area: str, write_file: bool = True):
     awfile = AREAS_FOLDER / "weights" / f"{area}_tmd_weights.csv.gz"
     wdf.to_csv(awfile, index=False, float_format="%.0f", compression="gzip")
 
-    return rmse
+    return 0
 
 
 if __name__ == "__main__":
@@ -424,4 +424,4 @@ if __name__ == "__main__":
             f"ERROR: {tfile} file not in tmd/areas/targets folder\n"
         )
         sys.exit(1)
-    create_area_weights_file(area_code, write_file=True)
+    sys.exit(create_area_weights_file(area_code, write_file=True))

--- a/tmd/areas/make_all.py
+++ b/tmd/areas/make_all.py
@@ -1,0 +1,109 @@
+"""
+Call create_area_weights.py for each out-of-date or non-existent
+weights file for which there is a targets file, and remove each
+weights file for which there is no corresponding targets file.
+"""
+
+import sys
+import time
+import subprocess
+from tmd.areas import AREAS_FOLDER
+from tmd.storage import STORAGE_FOLDER
+
+
+OTHER_DEPENDENCIES = [
+    AREAS_FOLDER / "create_area_weights.py",
+    STORAGE_FOLDER / "output" / "tmd.csv.gz",
+    STORAGE_FOLDER / "output" / "tmd_weights.csv.gz",
+    STORAGE_FOLDER / "output" / "tmd_growfactors.csv",
+    STORAGE_FOLDER / "input" / "cbo_population_forecast.yaml",
+    # Tax-Calculator is a dependency, so do "make tmd_files" when upgrading T-C
+]
+
+
+def time_of_newest_other_dependency():
+    """
+    Return time of newest file in the OTHER_DEPENDENCIES list.
+    """
+    max_dep_time = 0.0
+    for dpath in OTHER_DEPENDENCIES:
+        max_dep_time = max(dpath.stat().st_mtime, max_dep_time)
+    return max_dep_time
+
+
+# --- High-level logic of the script
+
+
+def make_all_areas():
+    """
+    Call create_area_weights.py for each out-of-date or non-existent
+    weights file for which there is a targets file.
+    """
+    # remove each weights file for which there is no correponding targets file
+    wfolder = AREAS_FOLDER / "weights"
+    wpaths = sorted(list(wfolder.glob("*_tmd_weights.csv.gz")))
+    for wpath in wpaths:
+        area = wpath.name.split("_")[0]
+        tpath = AREAS_FOLDER / "targets" / f"{area}_targets.csv"
+        lpath = AREAS_FOLDER / "targets" / f"{area}.log"
+        if not tpath.exists():
+            print(f"removing orphan weights file {wpath.name}")
+            wpath.unlink()
+            lpath.unlink(missing_ok=True)
+
+    # prepare area list of not up-to-date weights files
+    todo_areas = []
+    newest_dtime = time_of_newest_other_dependency()
+    tfolder = AREAS_FOLDER / "targets"
+    tpaths = sorted(list(tfolder.glob("*_targets.csv")))
+    for tpath in tpaths:
+        area = tpath.name.split("_")[0]
+        wpath = AREAS_FOLDER / "weights" / f"{area}_tmd_weights.csv.gz"
+        if wpath.exists():
+            wtime = wpath.stat().st_mtime
+        else:
+            wtime = 0.0
+        up_to_date = wtime > max(newest_dtime, tpath.stat().st_mtime)
+        if not up_to_date:
+            todo_areas.append(area)
+    if todo_areas:
+        msg = "(press Ctrl-C to stop)"
+        print(f"Plan to create_area_weights for the following areas {msg}:")
+        area_num = 0
+        for area in todo_areas:
+            area_num += 1
+            sys.stdout.write(f"{area:>5s}")
+            if area_num % 15 == 0:
+                sys.stdout.write("\n")
+        if area_num % 15 != 0:
+            sys.stdout.write("\n")
+
+    # process each target file for which the weights file is not up-to-date
+    for area in todo_areas:
+        time0 = time.time()
+        print(f"creating weights file and log file for {area} ...")
+        cmd = [
+            "python",
+            str(OTHER_DEPENDENCIES[0]),
+            area,
+        ]
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logpath = AREAS_FOLDER / "weights" / f"{area}.log"
+        with open(logpath, "w", encoding="utf-8") as logfile:
+            logfile.write(result.stdout)
+        exectime = time.time() - time0
+        if result.returncode != 0:
+            print(f"  ... failed after {exectime:.1f} secs")
+        else:
+            print(f"  ... finished after {exectime:.1f} secs")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(make_all_areas())

--- a/tmd/areas/make_all.py
+++ b/tmd/areas/make_all.py
@@ -34,7 +34,7 @@ def time_of_newest_other_dependency():
 # --- High-level logic of the script
 
 
-def make_all_areas():
+def make_all_areas(only_list=None):
     """
     Call create_area_weights.py for each out-of-date or non-existent
     weights file for which there is a targets file.
@@ -58,6 +58,8 @@ def make_all_areas():
     tpaths = sorted(list(tfolder.glob("*_targets.csv")))
     for tpath in tpaths:
         area = tpath.name.split("_")[0]
+        if only_list and area not in only_list:
+            continue  # skip this area
         wpath = AREAS_FOLDER / "weights" / f"{area}_tmd_weights.csv.gz"
         if wpath.exists():
             wtime = wpath.stat().st_mtime

--- a/tmd/areas/weights/bb.log-expect
+++ b/tmd/areas/weights/bb.log-expect
@@ -1,0 +1,65 @@
+CREATING WEIGHTS FILE FOR AREA bb ...
+INITIAL WEIGHTS STATISTICS:
+weights_scale= 9.874809e-02
+                s006        wght_us
+count  225256.000000  225256.000000
+mean      816.774828      80.654957
+std      1140.652664     112.637275
+min         0.110000       0.010862
+25%        23.570000       2.327493
+50%       389.695000      38.481638
+75%      1282.230000     126.617767
+max     15801.890000    1560.406500
+USING bb_targets.csv FILE CONTAINING 16 TARGETS
+DISTRIBUTION OF TARGET ACT/EXP RATIOS (n=16):
+low bin ratio    high bin ratio    bin #    cum #     bin %     cum %
+>=     0.400000, <     0.800000:       1        1     6.25%     6.25%
+>=     0.800000, <     0.900000:       1        2     6.25%    12.50%
+>=     0.900000, <     0.990000:       0        2     0.00%    12.50%
+>=     0.990000, <     0.999500:       0        2     0.00%    12.50%
+>=     0.999500, <     1.000500:       1        3     6.25%    18.75%
+>=     1.000500, <     1.010000:       0        3     0.00%    18.75%
+>=     1.010000, <     1.100000:       0        3     0.00%    18.75%
+>=     1.100000, <     1.200000:       0        3     0.00%    18.75%
+>=     1.200000, <     1.600000:       3        6    18.75%    37.50%
+>=     1.600000, <     2.000000:       0        6     0.00%    37.50%
+>=     2.000000, <     3.000000:       3        9    18.75%    56.25%
+>=     3.000000, <     4.000000:       2       11    12.50%    68.75%
+>=     4.000000, <     5.000000:       3       14    18.75%    87.50%
+>=     5.000000, <          inf:       2       16    12.50%   100.00%
+US_PROPORTIONALLY_SCALED_TARGET_RMSE= 3.031008582e+00
+target_matrix sparsity ratio = 0.597
+OPTIMIZE WEIGHT RATIOS IN A REGULARIZATION LOOP
+  where REGULARIZATION DELTA starts at 1.000000e-09
+  and where target_matrix.shape= (225256, 16)
+  ::loop,delta,misses,exectime(secs):   1   1.000000e-09   0   14.9
+>>> final delta loop exectime= 14.9 secs  iterations=168  success=True
+>>> message: CONVERGENCE: REL_REDUCTION_OF_F_<=_FACTR*EPSMCH
+>>> L-BFGS-B optimized objective function value: 1.261425278e-04
+AREA-OPTIMIZED_TARGET_MISSES= 0
+DISTRIBUTION OF TARGET ACT/EXP RATIOS (n=16):
+  with REGULARIZATION_DELTA= 1.000000e-09
+low bin ratio    high bin ratio    bin #    cum #     bin %     cum %
+>=     0.999500, <     1.000500:      16       16   100.00%   100.00%
+AREA-OPTIMIZED_TARGET_RMSE= 9.594020637e-05
+DISTRIBUTION OF AREA/US WEIGHT RATIO (n=225256):
+  with REGULARIZATION_DELTA= 1.000000e-09
+low bin ratio    high bin ratio    bin #    cum #     bin %     cum %
+>=     0.000000, <     0.000001:     633      633     0.28%     0.28%
+>=     0.000001, <     0.100000:   50851    51484    22.57%    22.86%
+>=     0.100000, <     0.200000:    8125    59609     3.61%    26.46%
+>=     0.200000, <     0.500000:   17983    77592     7.98%    34.45%
+>=     0.500000, <     0.800000:   28654   106246    12.72%    47.17%
+>=     0.800000, <     0.850000:    9340   115586     4.15%    51.31%
+>=     0.850000, <     0.900000:   12669   128255     5.62%    56.94%
+>=     0.900000, <     0.950000:   15103   143358     6.70%    63.64%
+>=     0.950000, <     1.000000:   19013   162371     8.44%    72.08%
+>=     1.000000, <     1.050000:   11368   173739     5.05%    77.13%
+>=     1.050000, <     1.100000:    5612   179351     2.49%    79.62%
+>=     1.100000, <     1.150000:    4492   183843     1.99%    81.62%
+>=     1.150000, <     1.200000:    4289   188132     1.90%    83.52%
+>=     1.200000, <     2.000000:   28332   216464    12.58%    96.10%
+>=     2.000000, <     5.000000:    8312   224776     3.69%    99.79%
+>=     5.000000, <    10.000000:     428   225204     0.19%    99.98%
+>=    10.000000, <   100.000000:      52   225256     0.02%   100.00%
+SUM OF SQUARED AREA/US WEIGHT RATIO DEVIATIONS= 1.259953e+05


### PR DESCRIPTION
Tool for automating the creation of many area weights files.

Supports the kinds of workflows described in issue #197.