### PR TITLE
Reduce create_area_weights.py FTOL and GTOL value from 1e-8 to 1e-9

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -39,8 +39,8 @@ DELTA_MAX_LOOPS = 5
 DELTA_LOOP_DECREMENT = DELTA_INIT_VALUE / (DELTA_MAX_LOOPS - 1)
 
 # optimization parameters:
-OPTIMIZE_FTOL = 1e-8
-OPTIMIZE_GTOL = 1e-8
+OPTIMIZE_FTOL = 1e-9
+OPTIMIZE_GTOL = 1e-9
 OPTIMIZE_MAXITER = 5000
 OPTIMIZE_IPRINT = 0  # 20 is a good diagnostic value; set to 0 for production
 OPTIMIZE_RESULTS = False  # set to True to see complete optimization results


### PR DESCRIPTION
In response to the discussion of merged PR #203 ending with [this comment](https://github.com/PSLmodels/tax-microdata-benchmarking/commit/538aa184b1bf899168e6ea124165ee5c362d7059#commitcomment-146927065).