### PR TITLE
Add ability to specify an optional area custom parameters file

### DIFF
--- a/tmd/areas/make_all.py
+++ b/tmd/areas/make_all.py
@@ -64,7 +64,13 @@ def to_do_areas(make_only_list=None):
             wtime = wpath.stat().st_mtime
         else:
             wtime = 0.0
-        up_to_date = wtime > max(newest_dtime, tpath.stat().st_mtime)
+        tpath_time = tpath.stat().st_mtime
+        ppath = AREAS_FOLDER / "targets" / f"{area}_params.yaml"
+        if ppath.exists():
+            ppath_time = ppath.stat().st_mtime
+        else:
+            ppath_time = 0.0
+        up_to_date = wtime > max(newest_dtime, tpath_time, ppath_time)
         if not up_to_date:
             todo_areas.append(area)
     return todo_areas

--- a/tmd/areas/targets/xx_params.yaml
+++ b/tmd/areas/targets/xx_params.yaml
@@ -1,0 +1,2 @@
+# custom parameters file for xx area:
+target_ratio_tolerance: 0.0005  # a more precise definition of "hitting target"


### PR DESCRIPTION
For an example, see the `areas/targets/xx_params.yaml` file.
Currently only the target_ratio_tolerance parameter can be customized.
