### PR TITLE
Use districts of the 118th Congress in create_area_weights.py

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -147,7 +147,8 @@ def valid_area(area: str):
         all_ok = False
     # check state congressional district number if appropriate
     if len(area) == 4:
-        max_cdn = state_info[scode][2010]  # assuming CDs based on 2010 Census
+        # assume CDs are based on 2020 Census (that is, 118th Congress)
+        max_cdn = state_info[scode][2020]
         if max_cdn <= 1:
             sys.stderr.write(
                 f": use area '{s_c}' for this one-district state\n"


### PR DESCRIPTION
Estimates of the 2021 population of the districts based on the 2020 Census are available from:
```
https://www2.census.gov/programs-surveys/acs/data/2021/CD118_Data_Profiles
```
where the relevant DP02 statistics are 
"ANCESTRY: Total population" or
"PLACE OF BIRTH: Total population",
both of which seem to be the same number.
