### PR TITLE
Update create_area_weights.py script

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -234,7 +234,7 @@ def prepared_data(area: str, vardf: pd.DataFrame):
         if row.count == 0:
             unmasked_varray = vardf[row.varname].astype(float)
         else:
-            unmasked_varray = (vardf[row.varname] > 0).astype(float)
+            unmasked_varray = (vardf[row.varname] > -np.inf).astype(float)
         mask = np.ones(numobs, dtype=int)
         assert (
             row.scope >= 0 and row.scope <= 2

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -293,6 +293,8 @@ def target_rmse(wght, target_matrix, target_array, out, delta=None):
     act = np.dot(wght, target_matrix)
     act_minus_exp = act - target_array
     ratio = act / target_array
+    min_ratio = np.min(ratio)
+    max_ratio = np.max(ratio)
     if DUMP_ALL_TARGET_DEVIATIONS:
         for tnum, ratio_ in enumerate(ratio):
             out.write(
@@ -342,6 +344,11 @@ def target_rmse(wght, target_matrix, target_array, out, delta=None):
         out.write(line)
         if cum == tot:
             break
+    # write minimum and maximum ratio values
+    line = f"MINIMUM VALUE OF TARGET ACT/EXP RATIO = {min_ratio:.3f}\n"
+    out.write(line)
+    line = f"MAXIMUM VALUE OF TARGET ACT/EXP RATIO = {max_ratio:.3f}\n"
+    out.write(line)
     # return RMSE of ACT-EXP targets
     return np.sqrt(np.mean(np.square(act_minus_exp)))
 

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -295,11 +295,12 @@ def target_rmse(wght, target_matrix, target_array, out, delta=None):
     ratio = act / target_array
     min_ratio = np.min(ratio)
     max_ratio = np.max(ratio)
-    if DUMP_ALL_TARGET_DEVIATIONS:
+    dump = PARAMS.get("dump_all_target_deviations", DUMP_ALL_TARGET_DEVIATIONS)
+    if dump:
         for tnum, ratio_ in enumerate(ratio):
             out.write(
                 f"TARGET{(tnum + 1):03d}:ACT-EXP,ACT/EXP= "
-                f"{act_minus_exp[tnum]:16.9e}, {ratio_:.3f}/n"
+                f"{act_minus_exp[tnum]:16.9e}, {ratio_:.3f}\n"
             )
     # show distribution of target ratios
     tol = PARAMS.get("target_ratio_tolerance", TARGET_RATIO_TOLERANCE)
@@ -470,6 +471,7 @@ def create_area_weights_file(
         exp_params = [
             "target_ratio_tolerance",
             "iprint",
+            "dump_all_target_deviations",
         ]
         if len(PARAMS) > len(exp_params):
             nump = len(exp_params)

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -418,8 +418,10 @@ def weight_ratio_distribution(ratio, delta, out):
         out.write(line)
         if cum == tot:
             break
-    ssqdev = np.sum(np.square(ratio - 1.0))
-    out.write(f"SUM OF SQUARED AREA/US WEIGHT RATIO DEVIATIONS= {ssqdev:e}\n")
+    # write RMSE of area/us weight ratio deviations from one
+    rmse = np.sqrt(np.mean(np.square(ratio - 1.0)))
+    line = f"RMSE OF AREA/US WEIGHT RATIO DEVIATIONS FROM ONE = {rmse:e}\n"
+    out.write(line)
 
 
 # -- High-level logic of the script:


### PR DESCRIPTION
Add several optimization parameters to the customizable PARAMS dictionary.
Change the default number of regularization loops from five to one, but this can be customized as can the initial regularization delta parameter value.  Also, fix a typo that was causing a bug.