### PR TITLE
Temporarily move back to using Congressional districts based on 2010 Census

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -147,8 +147,8 @@ def valid_area(area: str):
         all_ok = False
     # check state congressional district number if appropriate
     if len(area) == 4:
-        # assume CDs are based on 2020 Census (that is, 118th Congress)
-        max_cdn = state_info[scode][2020]
+        # assume CDs are based on 2010 Census (that is, 117th Congress)
+        max_cdn = state_info[scode][2010]
         cdn = int(area[2:4])
         if max_cdn <= 1:
             if cdn != 0:


### PR DESCRIPTION
Fixes #242 by implementing changes proposed in PR #244.

In the next few weeks the project will switch to using 118th Congressional districts based on the 2020 Census.