### PR TITLE
Add test of weighted number of tax units with zero AGI

### DIFF
--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -55,3 +55,5 @@ def test_income_tax():
     compare("wght_sum_hiagi", (wght * hiagi).sum(), 0.875e6, 0.01)
     compare("wght_itax_sum", (wght * itax).sum(), 1591e9, 0.01)
     compare("wght_itax_sum_hiagi", ((wght * itax) * hiagi).sum(), 902e9, 0.01)
+    # count weighted number of filing units with zero agi
+    compare("wght_sum_zeroagi", (wght * (agi == 0)).sum(), 16.22e6, 0.01)

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -49,11 +49,19 @@ def test_income_tax():
     wght = sim.array("s006")
     agi = sim.array("c00100")
     itax = sim.array("iitax")
+    mars = sim.array("MARS")
     # check various income tax statistics
     compare("wght_sum", wght.sum(), 184e6, 0.01)
     hiagi = agi >= 1e6
     compare("wght_sum_hiagi", (wght * hiagi).sum(), 0.875e6, 0.01)
     compare("wght_itax_sum", (wght * itax).sum(), 1591e9, 0.01)
     compare("wght_itax_sum_hiagi", ((wght * itax) * hiagi).sum(), 902e9, 0.01)
-    # count weighted number of filing units with zero agi
-    compare("wght_sum_zeroagi", (wght * (agi == 0)).sum(), 16.22e6, 0.01)
+    # count weighted number of tax units with zero agi by filing status
+    agi0 = agi == 0
+    compare("wght_sum_agi0_fs0", (wght * agi0).sum(), 16.22e6, 0.01)
+    mars1 = mars == 1
+    compare("wght_sum_agi0_fs1", (wght * mars1 * agi0).sum(), 12.01e6, 0.01)
+    mars2 = mars == 2
+    compare("wght_sum_agi0_fs2", (wght * mars2 * agi0).sum(), 2.00e6, 0.01)
+    mars4 = mars == 4
+    compare("wght_sum_agi0_fs4", (wght * mars4 * agi0).sum(), 1.53e6, 0.01)


### PR DESCRIPTION
These test results are useful in judging the sensibility of the changes in the specification of the `count` area targets file variable that were made in pull request #253.