### PR TITLE
Remove redundant code in create_area_weight.py

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -48,11 +48,6 @@ OPTIMIZE_MAXITER = 5000
 OPTIMIZE_IPRINT = 0  # 20 is a good diagnostic value; set to 0 for production
 OPTIMIZE_RESULTS = False  # set to True to see complete optimization results
 
-# assumption about which Congress the congressional districts are defined for:
-# ... 2010 implies districts for the 117th Congress
-# ... 2020 implies districts for the 118th Congress
-CD_CENSUS_YEAR = 2010
-
 
 def valid_area(area: str):
     """


### PR DESCRIPTION
Removes unused code mistakenly included in PR #267.
This is a cosmetic edit that causes no change in logic.
