### PR TITLE
Check area name validity using number of 118th Congressional districts

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -56,7 +56,7 @@ def valid_area(area: str):
     # Census on which Congressional districts are based:
     # : cd_census_year = 2010 implies districts are for the 117th Congress
     # : cd_census_year = 2020 implies districts are for the 118th Congress
-    cd_census_year = 2010
+    cd_census_year = 2020
     # data in the state_info dictionary is taken from the following document:
     #  2020 Census Apportionment Results, April 26, 2021,
     #  Table C1. Number of Seats in
@@ -124,6 +124,13 @@ def valid_area(area: str):
         total[2020] += seats[2020]
     assert total[2010] == 435
     assert total[2020] == 435
+    compare_new_vs_old = False
+    if compare_new_vs_old:
+        text = "state,2010cds,2020cds"
+        for state, seats in state_info.items():
+            if seats[2020] != seats[2010]:
+                print(f"{text}= {state} {seats[2010]:2d} {seats[2020]:2d}")
+        sys.exit(1)
     # conduct series of validity checks on specified area string
     # ... check that specified area string has expected length
     len_area_str = len(area)


### PR DESCRIPTION
This change to the `create_area_weights.py` script adds a few valid area names for the six states that gained Congressional districts after the 2020 Census redistricting and subtracts one district for the seven states that lost a district.   Here are those states:
```
GAINERS:
state,2010cds,2020cds= CO  7  8
state,2010cds,2020cds= FL 27 28
state,2010cds,2020cds= MT  1  2
state,2010cds,2020cds= NC 13 14
state,2010cds,2020cds= OR  5  6
state,2010cds,2020cds= TX 36 38

LOSERS:
state,2010cds,2020cds= CA 53 52
state,2010cds,2020cds= IL 18 17
state,2010cds,2020cds= MI 14 13
state,2010cds,2020cds= NY 27 26
state,2010cds,2020cds= OH 16 15
state,2010cds,2020cds= PA 18 17
state,2010cds,2020cds= WV  3  2
```

So, for example, after this change is merged into the master branch, `tx37` and `tx38` will be considered valid area names and `ca53` and `ny27` will be considered invalid area names.  

Note that as before `00` is a valid area number for all states regardless of the number of Congressional districts.  So, for example, after these changes are merged into the master branch, `mt00`, `mt01`, and `mt02` will be valid area names.

