### PR TITLE
cache all variables

### DIFF
--- a/tmd/create_taxcalc_cached_files.py
+++ b/tmd/create_taxcalc_cached_files.py
@@ -29,9 +29,11 @@ def create_cached_files():
     calc = tc.Calculator(policy=pol, records=rec)
     calc.advance_to_year(TAX_YEAR)
     calc.calc_all()
-    
+
     # cache all variables to aid in areas examination
-    calc.dataframe(variable_list=None, all_vars=True).to_csv(STORAGE_FOLDER / "output" / "cached_allvars.csv", index=None)
+    calc.dataframe(variable_list=None, all_vars=True).to_csv(
+        STORAGE_FOLDER / "output" / "cached_allvars.csv", index=None
+    )
 
     # write each variable in CACHED_TAXCALC_VARIABLES list to a binary file
     for vname in CACHED_TAXCALC_VARIABLES:

--- a/tmd/create_taxcalc_cached_files.py
+++ b/tmd/create_taxcalc_cached_files.py
@@ -29,6 +29,9 @@ def create_cached_files():
     calc = tc.Calculator(policy=pol, records=rec)
     calc.advance_to_year(TAX_YEAR)
     calc.calc_all()
+    
+    # cache all variables to aid in areas examination
+    calc.dataframe(variable_list=None, all_vars=True).to_csv(STORAGE_FOLDER / "output" / "cached_allvars.csv", index=None)
 
     # write each variable in CACHED_TAXCALC_VARIABLES list to a binary file
     for vname in CACHED_TAXCALC_VARIABLES:


### PR DESCRIPTION
Write all Tax-Calculator variables for TAX_YEAR to cached_allvars.csv in the storage output folder. After creating area weights, this file can be used in conjunction with those weights to analyze results for individual areas and across areas.

This PR could make tmd_2021.csv in the same folder superfluous, but does not eliminate creation of that file because that requires further investigation.