### PR TITLE
examine: add renv.lock

### DIFF
--- a/tmd/areas/weights/examine/renv.lock
+++ b/tmd/areas/weights/examine/renv.lock
@@ -1,6 +1,6 @@
 {
   "R": {
-    "Version": "4.4.1",
+    "Version": "4.4.2",
     "Repositories": [
       {
         "Name": "CRAN",


### PR DESCRIPTION
This PR only affects the R project `examine`. It makes no changes to python code and it makes no changes to substantive R code.

It simply updates the `renv.lock` file, making it easier for users to construct the R environment needed for the R project `examine`.