### PR TITLE
PR streamline targets for cd allreturns counts

### DIFF
--- a/tmd/areas/targets/prepare/prepare_cds/R/constants.R
+++ b/tmd/areas/targets/prepare/prepare_cds/R/constants.R
@@ -13,3 +13,5 @@ TMDHOME <- fs::path(here::here(), "..", "..", "..", "..", "..")
 # normalizePath(TMDHOME)
 TMDDATA <- fs::path(TMDHOME, "tmd", "storage", "output")
 # normalizePath(TMDDATA)
+
+CDAGICUTS <- c(-Inf, 1, 10e3, 25e3, 50e3, 75e3, 100e3, 200e3, 500e3, Inf)

--- a/tmd/areas/targets/prepare/prepare_cds/cd_compare_us_totals_tmd_vs_irs_published.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_compare_us_totals_tmd_vs_irs_published.qmd
@@ -30,7 +30,6 @@ fpath <-  fs::path(TMDDATA, "cached_allvars.csv")
 tmd2021 <- vroom(fpath)
 ns(tmd2021)
 
-
 ```
 
 ## Create comparison file
@@ -58,132 +57,163 @@ count(cd2 |> filter(str_detect(vname, "MARS")),
       vname, fstatus)
 skim(cd2)
 
+# get sums over all Congressional districts
 cd_adjusted <- cd2 |> 
-  summarise(target=sum(target),
-            .by=c(basevname, vname, scope, count, fstatus, agistub, agirange, description))
+  summarise(target=sum(target), n=n(),
+            .by=c(basevname, vname, scope, count, fstatus, agistub, agirange, description)) |> 
+  select(-n) # I want to look at n but not keep it in the file
 
 ```
 
 Prepare tmd data
 
+Start by getting desired sums and making long
+
 ```{r}
-#| label: prepare-tmd-data
+#| label: get-tmdsums-long
 #| eval: true
 #| output: false
 
-# 0 = Total
-# 1 = Under $1
-# 2 = $1 under $10,000
-# 3 = $10,000 under $25,000
-# 4 = $25,000 under $50,000
-# 5 = $50,000 under $75,000
-# 6 = $75,000 under $100,000
-# 7 = $100,000 under $200,000
-# 8 = $200,000 under $500,000
-# 9 = $500,000 or more
+# CDAGICUTS
 
-agicuts <- c(-Inf, 1, 10e3, 25e3, 50e3, 75e3, 100e3, 200e3, 500e3, Inf)
-
-variables_to_sum <- ifelse(str_starts(vmap$basevname, "MARS"),
-                   vmap$basevname,
-                   vmap$varname)
-
-tmd2 <- tmd2021 |> 
+ns(tmd2021)
+keepvars <- c("RECID", "data_source", "MARS", "s006", unique(vmap$varname))
+tmdprep <- tmd2021 |> 
+  select(all_of(keepvars)) |> 
   mutate(scope=ifelse(data_source==0, 2, 1),
-         MARS1=MARS==1, MARS2=MARS==2, MARS4=MARS==4,
-         agistub=cut(c00100, agicuts, right = FALSE, ordered_result = TRUE) |> 
-           as.integer()) |> 
-  summarize(across(all_of(variables_to_sum),
-                   list(amount = \(x) sum(x * s006),
-                        nzcount = \(x) sum((x!=0) * s006),
-                        allcount= \(x) sum(s006))),
-                   .by=c(scope, agistub)) |> 
+         agistub=cut(c00100, CDAGICUTS, right = FALSE, ordered_result = TRUE) |> 
+           as.integer(),
+         # create all-returns count variables fow which we want weighted sums
+         N1=1,
+         MARS1 = if_else(MARS == 1, 1, 0),
+         MARS2 = if_else(MARS == 2, 1, 0),
+         MARS4 = if_else(MARS == 4, 1, 0))
+# summary(tmdprep)
+
+sum_vars <- unique(vmap$varname)
+nzcount_vars <- setdiff(sum_vars, "XTOT")
+allcount_vars <- c("N1", "MARS1", "MARS2", "MARS4")
+
+tmdsums <- tmdprep |> 
+  # note that we get nzcount for AGI but don't have counterpart in the CD data
+  summarize(across(all_of(sum_vars), list(amount = \(x) sum(x * s006))),
+            across(all_of(nzcount_vars), list(nzcount = \(x) sum((x!=0) * s006))),
+            across(all_of(allcount_vars), list(allcount = \(x) sum((x==1) * s006))),
+            .by=c(scope, agistub)) |> 
   arrange(scope, agistub)
 
 # look at nzcounts
-tmd2 |> select(scope, agistub, contains("nzcount"))
-tmd2 |> select(scope, agistub, contains("allcount"))
-tmd2 |> select(scope, agistub, contains("amount"))
+tmdsums |> select(scope, agistub, contains("nzcount"))
+tmdsums |> select(scope, agistub, contains("allcount"))
+tmdsums |> select(scope, agistub, contains("amount"))
+tmdsums |> select(scope, agistub, N1_allcount, c00100_nzcount) |> mutate(ratio=c00100_nzcount / N1_allcount)
 
-tmd2 |> 
+tmdsums |> 
+  filter(scope==1) |> 
+  select(scope, agistub, e00200_nzcount) |> 
+  janitor::adorn_totals()
+
+tmdsums |> 
   filter(scope==1) |> 
   select(scope, agistub, contains("c00100") & contains("count")) |> 
   janitor::adorn_totals()
 
-
-# flip around and get count
-tmd3 <- tmd2 |> 
+# flip around and get count and fstatus
+tmdsums_long <- tmdsums |> 
   pivot_longer(cols=-c(scope, agistub), values_to = "wtdvalue") |> 
   separate_wider_delim(cols=name, delim="_", names=c("varname", "type")) |> 
-  mutate(count = case_when(
-    type == "amount"   ~ 0,
-    type == "nzcount"  ~ 2,
-    type == "allcount" ~ 1,
-    .default = -9e9))
-count(tmd3, count, type)
+  mutate(
+    count = case_when(
+      type == "amount"   ~ 0,
+      type == "allcount" ~ 1,
+      type == "nzcount"  ~ 2,
+      .default = -9e9),
+    fstatus=case_when(
+      varname %in% c("MARS1", "MARS2", "MARS4") ~ str_sub(varname, -1),
+      .default = "0"),
+    fstatus=as.integer(fstatus)) |> 
+  select(varname, scope, fstatus, count, agistub, wtdvalue)
+glimpse(tmdsums_long)
+count(tmdsums_long, count)
+count(tmdsums_long, fstatus)
 
-tmd3 |> filter(count==2, agistub==1) # looks good
-tmd3 |> filter(count==1, agistub==4) 
+tmdsums_long |> 
+  filter(varname=="e00200", scope==1, count==2) |> 
+  janitor::adorn_totals()
+
+tmdsums_long |> filter(count==2, agistub==1) # looks good
+tmdsums_long |> filter(count==1, agistub==4) 
 # 37,694,755 is the bad val allcount
+tmdsums_long |> filter(varname=="MARS1")
 
-# separate the mars and nonmars variables to get proper mars values
-tmdxmars <- tmd3 |> 
-  filter(str_detect(varname, "MARS", negate = TRUE)) |> 
-  filter(!(varname=="XTOT" & type != "amount")) |> 
-  mutate(fstatus=0) |> 
-  select(varname, scope, fstatus, count, agistub, wtdvalue) |> 
-  arrange(varname, scope, fstatus, count, agistub)
+```
 
-# tmdxmars |> filter(varname=="e00200", agistub==4) # we'll want count==2 for counts -- nonzero counts
 
-# check tmd mars totals
- tmd3 |> 
-   filter(str_detect(varname, "MARS")) |> 
-   summarize(wtdvalue=sum(wtdvalue),
-             .by=c(varname, scope, type, count))
- # this helps verify that we want type=="amount" as the number of returns
- # nothing else is useful
- # CAUTION: to be consistent with the xxxx_targets.csv file format rules
- # we need to set count to 1 (number of units with any value) INSTEAD of zero
- # and by convention we'll use c00100 as the variable name but any variable would be the same
- 
-tmdmars <- tmd3 |> 
-  filter(str_detect(varname, "MARS"),
-         type=="amount") |> 
-  mutate(fstatus=str_sub(varname, -1) |> 
-           as.integer(),
-         varname="c00100") |> 
-  select(varname, scope, fstatus, count, agistub, wtdvalue) |> 
-  arrange(varname, scope, fstatus, count, agistub)
+Add additional category sums
 
-# combine files and concatenate totals across agi ranges
-tmdsums1 <- bind_rows(tmdxmars, tmdmars)
-tmd_agitots <- tmdsums1 |> 
+```{r}
+
+# we don't need sums over scope because entire scope is 1 for this, other than population
+# we don't need sums over filing status because we're only concerned about selected fstatus
+
+# add sums over filing statuses as this is what we'll usually want
+# tmd_fstatustots <- tmdsums_long |>
+#   filter(!str_starts(varname, "MARS")) |> # we don't need MARS totals over all filing statuses
+#   summarise(wtdvalue=sum(wtdvalue),
+#                       .by=c(varname, scope, agistub, count)) |>
+#   mutate(fstatus=0) |>
+#   bind_rows(tmdsums_long)
+# count(tmd_fstatustots, varname)
+# tmd_fstatustots |> filter(varname=="MARS1")
+# tmd_fstatustots |> 
+#   filter(varname=="e00200", scope==1, count==2, fstatus==0) |> 
+#   janitor::adorn_totals()
+# tmd_fstatustots |> 
+#   filter(varname=="e00200", scope==1, count==0) |> 
+#   janitor::adorn_totals()
+
+
+# add sums over agi ranges
+tmd_agitots <- tmdsums_long |> 
   summarise(wtdvalue=sum(wtdvalue), 
                       .by=c(varname, scope, fstatus, count)) |> 
   mutate(agistub=0) |> 
-  bind_rows(tmdsums1)
+  bind_rows(tmdsums_long)
+tmd_agitots |> filter(varname=="MARS1")
+
+tmd_agitots |>
+  filter(varname=="e00200", scope==1, count==2, fstatus==0, agistub!=0) |>
+  janitor::adorn_totals()
 
 # concatenate totals across scopes
-tmd_scopes <- tmd_agitots |> 
+tmd_scopetots <- tmd_agitots |> 
   summarise(wtdvalue=sum(wtdvalue), 
                       .by=c(varname, agistub, fstatus, count)) |> 
   mutate(scope=0) |> 
   bind_rows(tmd_agitots) |> 
   select(varname, scope, fstatus, count, agistub, wtdvalue) |> 
   arrange(varname, scope, fstatus, count, agistub)
+# skim(tmd_scopetots)
+tmd_scopetots |> filter(varname=="MARS1")
+count(tmd_scopetots, varname)
 
-# we need to put fstatus on vmap for proper merging
-vmap2 <- vmap |> 
-  mutate(fstatus=case_when(basevname=="MARS1" ~ 1,
-                           basevname=="MARS2" ~ 2,
-                           basevname=="MARS4" ~ 4,
-                           .default = 0) |> 
-           as.integer())
+tmd_scopetots |>
+  filter(varname=="e00200", scope==1, count==2, fstatus==0, agistub!=0) |>
+  janitor::adorn_totals()
 
-tmd_adjusted <- tmd_scopes |> 
-  left_join(vmap2,
-            by = join_by(varname, fstatus))
+
+vmap_prep <- vmap |> 
+  mutate(varname=ifelse(basevname %in% allcount_vars, basevname, varname))
+
+# setequal(vmap_prep$varname, tmd_scopetots$varname)
+# setdiff(tmd_scopetots$varname, vmap_prep$varname)
+# setdiff(vmap_prep$varname, tmd_scopetots$varname)
+
+# put basevname and description onto the file
+tmd_adjusted <- tmd_scopetots |> 
+  left_join(vmap_prep, by = join_by(varname, fstatus))
+
+skim(tmd_adjusted)
 
 ```
 
@@ -195,19 +225,28 @@ tmd_adjusted <- tmd_scopes |>
 #| eval: true
 #| output: false
 
+count(tmd_adjusted, basevname)
+count(cd_adjusted, basevname)
+
+cd_adjusted2 <- cd_adjusted |> 
+  mutate(basevname=ifelse(vname %in% allcount_vars,
+                          vname, 
+                          basevname))
+
 comp <- tmd_adjusted |> 
   select(-description) |> 
-  inner_join(cd_adjusted,
+  inner_join(cd_adjusted2,
             by = join_by(scope, fstatus, count, agistub, basevname)) |> 
   relocate(wtdvalue, .after = target) |> 
   mutate(diff=wtdvalue - target,
          pdiff=diff / target)
 summary(comp)
-skim(comp)
+skim(comp) # will generate Inf, -Inf warning
 
 write_csv(comp, fs::path(CDINTERMEDIATE, "cd_tmd_irs_compare.csv"))
 
 ```
+
 
 ## Explore comparisons file
 
@@ -228,6 +267,14 @@ badmatches <- c("e18400", "e18500", "e02400", "e26270") # to make it easier to e
 check <- comp |> 
   filter(!varname %in% badmatches, count==2) |> 
   arrange(desc(abs(pdiff)))
+
+check <- comp |> 
+  filter(!varname %in% badmatches, count==1) |> 
+  arrange(desc(abs(pdiff)))
+
+comp |> filter(!varname %in% badmatches, count==0, agistub==0) |> gt() |> fmt_number(columns = c(target, wtdvalue, diff), decimals = 0)
+comp |> filter(!varname %in% badmatches, count==1, agistub==0) |> gt() |> fmt_number(columns = c(target, wtdvalue, diff), decimals = 0)
+comp |> filter(!varname %in% badmatches, count==2, agistub==0) |> gt() |> fmt_number(columns = c(target, wtdvalue, diff), decimals = 0)
 
 tmd2021 |> 
   filter(data_source==1, c00100 != 0) |> 
@@ -277,6 +324,15 @@ verybad |>
 #      should we create a shared-down variable?
 #  - e00300 taxable interest seems a little off
 
+# agistub 0 
+#   n returns with taxable interest tmd >> cd
+#                  wages tmd >> cd  
+#   wage target 124333630 wage CD file: 124333630 wage natl file irs table 1.4 126,082,290
+#   but we say wtdvalue is 252208964 ?? actual is 126104482
+tmd2021 |> 
+  summarise(nwages=sum(s006 * (e00200 != 0)),
+            wages=sum(s006 * e00200),
+            .by=data_source)
 
 ```
 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_construct_long_soi_data_file.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_construct_long_soi_data_file.qmd
@@ -39,25 +39,6 @@ Create and map AGI bin labels to the AGI bins that SOI uses, and save in ".../cd
 #| label: agi-bins
 #| output: false
 
-# example of targets file
-# varname,count,scope,agilo,agihi,fstatus,target
-# XTOT,       0,    0,-9e99, 9e99,      0,  33e6
-# e00300,     0,    1,-9e99, 9e99,      0,  20e9
-# e00900,     0,    1,-9e99, 9e99,      0,  30e9
-# e00200,     0,    1,-9e99, 9e99,      0,1000e9
-# e02000,     0,    1,-9e99, 9e99,      0,  30e9
-# e02400,     0,    1,-9e99, 9e99,      0,  60e9
-# c00100,     0,    1,-9e99, 9e99,      0,1200e9
-# XTOT,       1,    1,  1e6, 9e99,      0,  10e3
-# e00400,     0,    1,-9e99, 9e99,      0,   2e9
-# e00600,     0,    1,-9e99, 9e99,      0,   8e9
-# e00650,     0,    1,-9e99, 9e99,      0,   7e9
-# e01700,     0,    1,-9e99, 9e99,      0,  12e9
-# e02300,     0,    1,-9e99, 9e99,      0,  10e9
-# e17500,     0,    1,-9e99, 9e99,      0,   5e9
-# e18400,     0,    1,-9e99, 9e99,      0,  10e9
-# e18500,     0,    1,-9e99, 9e99,      0,  10e9
-
 # in_bin = (vardf.c00100 >= row.agilo) & (vardf.c00100 < row.agihi)
 
 # 0 = Total
@@ -119,7 +100,7 @@ Get previously downloaded IRS SOI data with aggregate information for individual
 #| eval: true
 #| output: false
 
-# read the csv file from the zip archive that contains it
+# read the CD csv data file from the zip archive that contains it
 zpath <-  fs::path(CDRAW, fs::path_file(CDZIPURL))
 con <- unz(zpath, "21incd.csv")
 data <- read_csv(con)
@@ -189,7 +170,7 @@ rm(data, data2, cdnums)
 ## Create long SOI data file
 
 -   convert to a long file
--   merge with variable documenttion file
+-   merge with variable documentation file
 -   save as "cddata_long_clean.csv" in intermediate file directory
 
 ```{r}
@@ -216,6 +197,7 @@ dlong1 <- cdwide |>
 glimpse(dlong1)
 count(dlong1, vname)
 count(dlong1, vtype)
+check <- count(dlong1, basevname, vname)
 
 write_csv(dlong1, fs::path(CDINTERMEDIATE, "cddata_long_clean.csv"))
 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_construct_soi_variable_documentation.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_construct_soi_variable_documentation.qmd
@@ -66,7 +66,10 @@ doc3 <- doc2 |>
                          NA_character_)) |> 
   arrange(suffix, vname) |> 
   mutate(nvars = n(), .by=suffix) |> 
-  mutate(basevname= ifelse(nvars==2,
+  # basevname is the "base" variable name when we might have both a count and an amount
+  # 2 variables A00100 and A00101 do not follow this format but we 
+  # may create counts for them later so we still want a basevname
+  mutate(basevname= ifelse(nvars==2 | vname %in% c("A00100", "A00101"),
                            paste0("v", suffix),
                            NA_character_)) |> 
   select(-c(nvars, suffix)) |> 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_create_basefile_for_117Congress_cd_target_files.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_create_basefile_for_117Congress_cd_target_files.qmd
@@ -35,6 +35,7 @@ source(here::here("R", "functions.R"))
 #| label: get-soi-based-data
 
 cdlong <- read_csv(fs::path(CDINTERMEDIATE, "cddata_long_clean.csv"))
+check <- count(cdlong, basevname, vname)
 
 ```
 
@@ -78,38 +79,86 @@ rm(dropvars)
 ```
 
 
-### Address agi issue
+### Create nzcount and allcount concepts
 
-We have an issue with AGI: for Congressional Districts IRS does NOT report the number of returns with AGI. See the discussion on the introduction page.
+We have an issue with AGI: for Congressional Districts IRS does NOT report the number of returns with nonzero AGI. See the discussion on the introduction page.
+
+However, we have N1, which is a count of all returns by agi range.
+
+Also, we have marital status counts (MARS1, MARS2, and MARS4), but they are not non-zero counts but rather counts of tax units with that filing status.
+
+Solution:
+- create vtype category of nzcount (nonzero count), which is what most count variables will have
+- and vtype category of allcount, for N1, MARS2, MARS2, and MARS4.
+- associate all of these with v00100
 
 We are going to create new rows for N00100 (Number of returns with AGI (estimated)), equal to N1, add it to the data.
 
+Note that this will (get allcount, count=1) (i.e., number of tax units with any value of varname) whereas other count measures will (get nzcount, count=2) (number of tax units with a nonzero value of varname). See the [documentation](https://github.com/PSLmodels/tax-microdata-benchmarking/tree/master/tmd/areas/targets).
+
 ```{r}
-#| label: address-agi
-#| output: false
+# vname = "N00100",         basevname = "v00100",
 
-nagi <- cdlong2 |> 
-  filter(vname == "N1") |> 
-  mutate(vname = "N00100",
-         basevname = "v00100",
-         description = "Number of returns with Adjusted Gross Income - AGI (estimated)")
+count(cdlong2, vtype)
+skim(cdlong2)
 
-cdlong3 <- bind_rows(cdlong2, nagi) |> 
-  mutate(basevname = ifelse(vname == "A00100",
-                            "v00100",
-                            basevname))
+marstats <- c("MARS1", "MARS2", "MARS4")
+allcounts <- c("N1", "MARS1", "MARS2", "MARS4")
 
-# check
-check <- cdlong3 |> 
-  filter(basevname=="v00100", STATE=="WY") |> 
-  arrange(STATE, CONG_DISTRICT, basevname, desc(vtype), AGI_STUB)
+cdlong3 <- cdlong2 |> 
+  mutate(
+    fstatus=case_when(
+    vname %in% marstats ~ str_sub(vname, -1),
+    .default = "0"),
+    fstatus=as.integer(fstatus),
+    
+    vtype = case_when(
+      vname %in% allcounts ~ "allcount",
+      vtype == "count" ~ "nzcount",
+      .default = vtype),
+    
+    basevname = ifelse(vname %in% allcounts, "v00100", basevname), # use AGI for allcounts variables
+    description = ifelse(vname %in% allcounts, "Number of returns", description)
+    )
 
-rm(nagi, check)
+count(cdlong3, fstatus)
+count(cdlong3, vtype)
+count(cdlong3, fstatus, vtype)
+
 
 ```
 
 
-### Define statecd, fstatus, scope, count; put amounts in dollars; sort
+
+```{r}
+#| label: address-agi
+#| eval: false
+#| output: false
+
+# count(cdlong2, vtype)
+# 
+# nagi <- cdlong2 |> 
+#   filter(vname == "N1") |> 
+#   mutate(vname = "N00100",
+#          basevname = "v00100",
+#          description = "Number of returns with Adjusted Gross Income - AGI (estimated)")
+# 
+# cdlong3 <- bind_rows(cdlong2, nagi) |> 
+#   mutate(basevname = ifelse(vname == "A00100",
+#                             "v00100",
+#                             basevname))
+
+# check
+# check <- cdlong3 |> 
+#   filter(basevname=="v00100", STATE=="WY") |> 
+#   arrange(STATE, CONG_DISTRICT, basevname, desc(vtype), AGI_STUB)
+# 
+# rm(nagi, check)
+
+```
+
+
+### Define statecd, scope, count; put amounts in dollars; sort
 
 ```{r}
 #| label: fstatus-misc
@@ -117,15 +166,11 @@ rm(nagi, check)
 
 cdlong4 <- cdlong3 |> 
     mutate(
-      fstatus = case_when(
-        vname == "MARS1" ~ 1,
-        vname == "MARS2" ~ 2,
-        vname == "MARS4" ~ 4, # VERIFY WITH MARTIN
-        .default = 0),
       
       count = case_when(
-        vtype == "count" ~ 2, # correction - used to be 1
         vtype == "amount" ~ 0,
+        vtype == "allcount" ~ 1,
+        vtype == "nzcount" ~ 2,
         .default = -99),
       
       scope = 1,
@@ -139,6 +184,7 @@ cdlong4 <- cdlong3 |>
 # count(cdlong4, fstatus)
 # count(cdlong4, count, vtype)
 # count(cdlong4, scope)
+check <- count(cdlong4, basevname, vname)
 
 ```
 
@@ -217,6 +263,9 @@ cdbasefile <- bind_rows(cdlong4 |>
 # glimpse(cdbasefile)
 # summary(cdbasefile)
 # skim(cdbasefile)
+check <- count(cdbasefile, basevname, vname)
+
+
 
 cdbasefile |> count(basevname)
 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_create_basefile_for_117Congress_cd_target_files.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_create_basefile_for_117Congress_cd_target_files.qmd
@@ -35,7 +35,7 @@ source(here::here("R", "functions.R"))
 #| label: get-soi-based-data
 
 cdlong <- read_csv(fs::path(CDINTERMEDIATE, "cddata_long_clean.csv"))
-check <- count(cdlong, basevname, vname)
+# check <- count(cdlong, basevname, vname)
 
 ```
 
@@ -97,7 +97,8 @@ We are going to create new rows for N00100 (Number of returns with AGI (estimate
 Note that this will (get allcount, count=1) (i.e., number of tax units with any value of varname) whereas other count measures will (get nzcount, count=2) (number of tax units with a nonzero value of varname). See the [documentation](https://github.com/PSLmodels/tax-microdata-benchmarking/tree/master/tmd/areas/targets).
 
 ```{r}
-# vname = "N00100",         basevname = "v00100",
+#| label: fstatus-and-vtype
+#| output: false
 
 count(cdlong2, vtype)
 skim(cdlong2)
@@ -125,48 +126,17 @@ count(cdlong3, fstatus)
 count(cdlong3, vtype)
 count(cdlong3, fstatus, vtype)
 
-
-```
-
-
-
-```{r}
-#| label: address-agi
-#| eval: false
-#| output: false
-
-# count(cdlong2, vtype)
-# 
-# nagi <- cdlong2 |> 
-#   filter(vname == "N1") |> 
-#   mutate(vname = "N00100",
-#          basevname = "v00100",
-#          description = "Number of returns with Adjusted Gross Income - AGI (estimated)")
-# 
-# cdlong3 <- bind_rows(cdlong2, nagi) |> 
-#   mutate(basevname = ifelse(vname == "A00100",
-#                             "v00100",
-#                             basevname))
-
-# check
-# check <- cdlong3 |> 
-#   filter(basevname=="v00100", STATE=="WY") |> 
-#   arrange(STATE, CONG_DISTRICT, basevname, desc(vtype), AGI_STUB)
-# 
-# rm(nagi, check)
-
 ```
 
 
 ### Define statecd, scope, count; put amounts in dollars; sort
 
 ```{r}
-#| label: fstatus-misc
+#| label: categoricals-misc
 #| output: false
 
 cdlong4 <- cdlong3 |> 
     mutate(
-      
       count = case_when(
         vtype == "amount" ~ 0,
         vtype == "allcount" ~ 1,
@@ -184,7 +154,7 @@ cdlong4 <- cdlong3 |>
 # count(cdlong4, fstatus)
 # count(cdlong4, count, vtype)
 # count(cdlong4, scope)
-check <- count(cdlong4, basevname, vname)
+# check <- count(cdlong4, basevname, vname)
 
 ```
 
@@ -252,7 +222,6 @@ cdbasefile <- bind_rows(cdlong4 |>
                         cdpop2 |> mutate(src="census")) |> 
   mutate(statecd = paste0(STATE, CONG_DISTRICT),
          basevname=case_when(
-           is.na(basevname) & vname=="A00101" ~ "v00101", # special handling
            is.na(basevname) ~ vname,
            .default = basevname)) |> # THINK ABOUT THIS CAREFULLY
   select(src, rectype, stabbr=STATE, cd=CONG_DISTRICT, statecd,
@@ -263,17 +232,15 @@ cdbasefile <- bind_rows(cdlong4 |>
 # glimpse(cdbasefile)
 # summary(cdbasefile)
 # skim(cdbasefile)
-check <- count(cdbasefile, basevname, vname)
+# check <- count(cdbasefile, basevname, vname)
+# cdbasefile |> count(basevname)
+check <- count(cdbasefile, src, scope, fstatus, count)
 
-
-
-cdbasefile |> count(basevname)
-
+cdbasefile |> filter(statecd=="WY00", scope==1, fstatus==0, count==1)
 cdbasefile |> filter(statecd=="WY00", agistub==0, basevname=="v00100")
 cdbasefile |> filter(statecd=="WY00", agistub==0, basevname=="v00101")
 
 write_csv(cdbasefile, fs::path(CDINTERMEDIATE, "cdbasefile_117.csv"))
 
 ```
-
 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_create_basefile_multiple_sessions.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_create_basefile_multiple_sessions.qmd
@@ -24,7 +24,8 @@ source(here::here("R", "functions.R"))
 ## Get data
 
 ```{r}
-
+#| label: stack-sessions
+#| output: false
 
 cd117 <- read_csv(fs::path(CDINTERMEDIATE, "cdbasefile_117.csv"))
 cd118 <- read_csv(fs::path(CDINTERMEDIATE, "cdbasefile_118.csv"))
@@ -50,7 +51,10 @@ states |>
          pdiff=diff / s117) |> 
   arrange(desc(abs(pdiff))) # good all the state sums work
 
+# check <- count(stack, basevname, vname)
+
 write_csv(stack, fs::path(CDINTERMEDIATE, "cdbasefile_sessions.csv"))
+
 
 ```
 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_create_cd_117_118_crosswalk_and_cdbasefile_118.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_create_cd_117_118_crosswalk_and_cdbasefile_118.qmd
@@ -24,8 +24,6 @@ source(here::here("R", "libraries.R"))
 source(here::here("R", "constants.R"))
 source(here::here("R", "functions.R"))
 
-# phase4_statecds <- c("AK00", "DE00", "ID01", "ID02", "ME02", "MT00", "ND00", "PA08", "SD00", "WY00")
-
 ```
 
 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_create_variable_mapping.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_create_variable_mapping.qmd
@@ -23,9 +23,12 @@ source(here::here("R", "functions.R"))
 ```{r}
 #| label: create-save-variable-mapping
 
-vmap <- read_csv(file="
+# varname is the name used in python code for target variables
+
+vmap1 <- read_csv(file="
 varname, basevname, description
 XTOT, XTOT, Population
+c00100, N1, Total number of returns
 c00100, MARS1, fstatus == 1
 c00100, MARS2, fstatus == 2
 c00100, MARS4, fstatus == 4
@@ -43,6 +46,16 @@ e02400, v02500, Social Security total
 #   e18400 is not reported for districts; we have allocated it to districts by S&L income taxes
 #   e2500 is not reported for districts; allocated to districts by e2500 taxable Social Security
 
+# note that we hard-code filing status. this works for Congressional districts
+# because we do not have data by filing status but it may not work for states
+# RECONSIDER THIS
+vmap <- vmap1 |> 
+  mutate(
+    fstatus=case_when(
+      str_detect(basevname, "MARS") ~ str_sub(basevname, -1),
+      .default = "0"),
+    fstatus=as.integer(fstatus)
+    )
 
 write_csv(vmap, fs::path(CDINTERMEDIATE, "cd_variable_mapping.csv"))
 

--- a/tmd/areas/targets/prepare/prepare_cds/cd_enhance_basefile_with_special_targets.qmd
+++ b/tmd/areas/targets/prepare/prepare_cds/cd_enhance_basefile_with_special_targets.qmd
@@ -61,16 +61,6 @@ source(here::here("R", "functions.R"))
 
 ```
 
-Define the agi cutpoints that the IRS uses in its published 2021 Congressional district data.
-
-```{r}
-#| label: agi-cutpoints
-
-# Define the agi cutpoints that the IRS uses in its published 2021 Congressional district data
-icuts <- c(-Inf, 1, 10e3, 25e3, 50e3, 75e3, 100e3, 200e3, 500e3, Inf)
-
-```
-
 Get the unenhanced target data and the tmd2021 cached data.
 
 ```{r}
@@ -186,7 +176,7 @@ Make preliminary salt targets.
 
 saltus <- tmd2021 |> 
   select(RECID, data_source, s006, c00100, e18400, e18500) |> 
-  mutate(irange=cut(c00100, icuts, right = FALSE, ordered_result = TRUE),
+  mutate(irange=cut(c00100, CDAGICUTS, right = FALSE, ordered_result = TRUE),
          irange = factor(irange, 
                          levels = levels(irange), # Ensure ordering is maintained
                          labels = str_replace(levels(irange), ",", ", ")), # more-readable labels
@@ -372,7 +362,7 @@ Make preliminary Social Security targets.
 
 socsecus <- tmd2021 |> 
   select(RECID, data_source, s006, c00100, e02400) |> 
-  mutate(irange=cut(c00100, icuts, right = FALSE, ordered_result = TRUE),
+  mutate(irange=cut(c00100, CDAGICUTS, right = FALSE, ordered_result = TRUE),
          irange = factor(irange, 
                          levels = levels(irange), # Ensure ordering is maintained
                          labels = str_replace(levels(irange), ",", ", ")), # more-readable labels

--- a/tmd/areas/targets/prepare/prepare_cds/cdrecipes/phase6_add_socsec.json
+++ b/tmd/areas/targets/prepare/prepare_cds/cdrecipes/phase6_add_socsec.json
@@ -4,9 +4,9 @@
   "session": 118, // not present, or 117 or 118
   
 	// "cdlist": "all",  // all, or a list such as ["AK00", "DE00"],
-	"cdlist": ["NY21"],   // all, or a list such as ["AK00", "DE00"],
+	// "cdlist": ["NY21"],   // all, or a list such as ["AK00", "DE00"],
 	// "cdlist": ["AK00", "DE00"],   // all, or a list such as ["AK00", "DE00"],
-  // "cdlist": ["AK00", "DE00", "ID01", "ID02", "ME02", "MT00", "ND00", "PA08", "SD00", "WY00"],
+  "cdlist": ["AK00", "DE00", "ID01", "ID02", "ME02", "MT00", "ND00", "PA08", "SD00", "WY00"],
 	
 	// target parameters
 	"notzero": true, // true or false
@@ -27,19 +27,19 @@
     {
       "varname": "c00100",
       "scope": 1,
-      "count": 2,
+      "count": 1,
       "fstatus": 1
     },      
     {
       "varname": "c00100",
       "scope": 1,
-      "count": 2,
+      "count": 1,
       "fstatus": 2
     },      
     {
       "varname": "c00100",
       "scope": 1,
-      "count": 2,
+      "count": 1,
       "fstatus": 4
     },          
     {


### PR DESCRIPTION
This PR does not change any python code.

The PR improves R code but does not make significant substantive changes.

This improves the way in which "all counts" targets are processed and stored, making it easier to create xxxx_targets.csv files that include these targets. ("all counts" targets are targets for the numbers of returns for a variable, regardless of the variable's value.)

The code still needs substantial cleanup and documentation but is substantially improved so I am creating this PR.