### PR TITLE
PR prepare state variable documentation

### DIFF
--- a/tmd/areas/targets/prepare/prepare_states/.gitignore
+++ b/tmd/areas/targets/prepare/prepare_states/.gitignore
@@ -34,3 +34,5 @@ _web/
 !states/raw_data/**
 # Continue to ignore Word temp files
 states/raw_data/~*
+
+/.quarto/

--- a/tmd/areas/targets/prepare/prepare_states/.gitignore
+++ b/tmd/areas/targets/prepare/prepare_states/.gitignore
@@ -1,37 +1,36 @@
-# prepare_states
-
-# ignore quarto at the root level
-/.quarto/
-
-# folders to ignore (anywhere in project since not preceded by root /)
+# Ignore RStudio and Quarto settings
 .Rproj.user/
-#_docs/
-#_targetprep/
-#_freeze/
-_web/
-#libs/
-# Local Netlify folder
-.netlify
+.quarto/
 
-# Ignore `renv` directories that are system-specific
+# Ignore system-specific renv directories
 renv/library/
 renv/cache/
 
-# Track the lockfile and settings file for reproducibility
+# Track renv lockfile and settings
 !renv.lock
 !renv/settings.dcf
 
-# file types to ignore (unless not ignored elsewhere)
+# Ignore Netlify folder
+.netlify
+
+# Ignore generated folders and websites
+_web/
+#_docs/
+#_targetprep/
+#_freeze/
+#libs/
+
+# Ignore file types generated during work, unless tracked explicitly
 ~*
 *.csv
 *.html
 *.rds
 
-# specific files to ignore regardless of how file types are treated
+# Specific files to ignore
 .Rhistory
+.RData
 
-# Do not ignore anything in raw data folder, including files or folders nested within
+# Do not ignore anything in raw data folder, including nested files or folders
 !states/raw_data/**
-# but continue to ignore Word temp files
+# Continue to ignore Word temp files
 states/raw_data/~*
-

--- a/tmd/areas/targets/prepare/prepare_states/R/constants.R
+++ b/tmd/areas/targets/prepare/prepare_states/R/constants.R
@@ -1,17 +1,23 @@
 
-CDZIPURL <- "https://www.irs.gov/pub/irs-soi/congressional2021.zip"
-CDDOCURL <- "https://www.irs.gov/pub/irs-soi/21incddocguide.docx"
+DRAW <- here::here("data", "data_raw")
+DINTERMEDIATE <- here::here("data", "intermediate")
 
-CDDIR <- here::here("cds")
-CDRAW <- fs::path(CDDIR, "raw_data")
-CDINTERMEDIATE <- fs::path(CDDIR, "intermediate")
-CDFINAL <- fs::path(CDDIR, "final")
-
-CDDOCEXTRACT <- "cd_documentation_extracted_from_21incddocguide.docx.xlsx"
-
-TMDHOME <- fs::path(here::here(), "..", "..", "..", "..", "..")
-# normalizePath(TMDHOME)
-TMDDATA <- fs::path(TMDHOME, "tmd", "storage", "output")
-# normalizePath(TMDDATA)
 
 CDAGICUTS <- c(-Inf, 1, 10e3, 25e3, 50e3, 75e3, 100e3, 200e3, 500e3, Inf)
+
+# CDZIPURL <- "https://www.irs.gov/pub/irs-soi/congressional2021.zip"
+# CDDOCURL <- "https://www.irs.gov/pub/irs-soi/21incddocguide.docx"
+# 
+# CDDIR <- here::here("cds")
+# CDRAW <- fs::path(CDDIR, "raw_data")
+# CDINTERMEDIATE <- fs::path(CDDIR, "intermediate")
+# CDFINAL <- fs::path(CDDIR, "final")
+# 
+# CDDOCEXTRACT <- "cd_documentation_extracted_from_21incddocguide.docx.xlsx"
+# 
+# TMDHOME <- fs::path(here::here(), "..", "..", "..", "..", "..")
+# # normalizePath(TMDHOME)
+# TMDDATA <- fs::path(TMDHOME, "tmd", "storage", "output")
+# # normalizePath(TMDDATA)
+# 
+

--- a/tmd/areas/targets/prepare/prepare_states/_quarto.yml
+++ b/tmd/areas/targets/prepare/prepare_states/_quarto.yml
@@ -42,7 +42,7 @@ book:
       chapters:
         # - cd_download_and_clean_census_population_data.qmd
         - download_soi_data.qmd
-        - get_soi_documentation.qmd
+        - construct_soi_documentation.qmd
         # - explore_soi_data.qmd
         # - analyze_SALT.qmd
         # - cd_construct_soi_variable_documentation.qmd
@@ -64,6 +64,8 @@ format:
 
 editor_options:
   chunk_output_type: console
+  
+# 5 states to do:  NJ, NM, VA, AK, MN  
 
 # rendering commands
 #   quarto render

--- a/tmd/areas/targets/prepare/prepare_states/_quarto.yml
+++ b/tmd/areas/targets/prepare/prepare_states/_quarto.yml
@@ -42,7 +42,9 @@ book:
       chapters:
         # - cd_download_and_clean_census_population_data.qmd
         - download_soi_data.qmd
-        - explore_soi_data.qmd
+        - get_soi_documentation.qmd
+        # - explore_soi_data.qmd
+        # - analyze_SALT.qmd
         # - cd_construct_soi_variable_documentation.qmd
         # - cd_construct_long_soi_data_file.qmd
         # - cd_create_basefile_for_117Congress_cd_target_files.qmd

--- a/tmd/areas/targets/prepare/prepare_states/construct_soi_documentation.qmd
+++ b/tmd/areas/targets/prepare/prepare_states/construct_soi_documentation.qmd
@@ -15,12 +15,21 @@ source(here::here("R", "libraries.R"))
 source(here::here("R", "constants.R"))
 source(here::here("R", "functions.R"))
 
+library(stringdist) # for calculating "distances" between strings
+
 ```
 
-## Read, combine, and save the documentation data
+## Read, stack, and save the documentation data
+
+### Read and stack documentation files for different years
+
+Start with *soi_states_variable_documentation.xlsx*, a hand-created workbook that has a sheet for each year from 2015-2021. Each sheet has a table from the SOI documentation file for that year, with variable names, variable descriptions, and certain other information. For example, the SOI file for 2021 is named *21incmdocguide.doc*. 
+
+See the notes sheet in the workbook for how the Word tables were copied to Excel. The basic idea was to copy each table to a sheet and make the absolute minimum manual changes needed to make the table rectangular and computer-readable. The goal is to do as much parsing and cleaning in computer code as possible to reduce risk of errors and make it reproducible.
+
 
 ```{r}
-#| label: combine-documentation
+#| label: stack-documentation
 #| output: false
 
 fname <- "soi_states_variable_documentation.xlsx"
@@ -28,20 +37,20 @@ fpath <- fs::path(DRAW, fname)
 
 f <- function(year){
   df1 <- readxl::read_xlsx(fpath, sheet = as.character(year), col_types = "text")
-df2 <- df1 |> 
-  select(vname=1, description=2, reference=3, type=4) |> 
-  filter(if_any(everything(), ~!is.na(.))) |> 
-  # after verifying that AGI_STUB is the only variable with NA in vname
-  # fill down and then concatenate the reference column
-  fill(vname, description, type, .direction="down") |> 
-  mutate(reference = paste(reference, collapse = "\n"), .by=vname) |> 
-  distinct() |> 
-  # for now, make mistaken references NA
-  mutate(reference=ifelse(!is.na(as.numeric(reference)), NA_character_, reference),
-         reference=ifelse(reference=="NA", NA_character_, reference),
-         year=!!year) |> 
-  relocate(year)
-df2
+  df2 <- df1 |> 
+    select(vname=1, description=2, reference=3, type=4) |> 
+    filter(if_any(everything(), ~!is.na(.))) |> 
+    # after verifying that AGI_STUB is the only variable with NA in vname
+    # fill down and then concatenate the reference column
+    fill(vname, description, type, .direction="down") |> 
+    mutate(reference = paste(reference, collapse = "\n"), .by=vname) |> 
+    distinct() |> 
+    # for now, make mistaken references NA
+    mutate(reference=ifelse(!is.na(as.numeric(reference)), NA_character_, reference),
+           reference=ifelse(reference=="NA", NA_character_, reference),
+           year=!!year) |> 
+    relocate(year)
+  df2
 }
 
 # f(2021)
@@ -52,10 +61,10 @@ df2
 # f(2016)
 # f(2015)
 
-df <- purrr::map(2015:2021, f) |> 
+stacked_docs <- purrr::map(2015:2021, f) |> 
   list_rbind()
 
-count(df, year)
+count(stacked_docs, year)
 
 # write_csv(df, fs::path(DINTERMEDIATE, "soi_documentation.csv"))
 
@@ -66,7 +75,7 @@ count(df, year)
 
 # identify variables that have more than one description, and then
 # identify instances where the descriptions are highly dissimilar
-library(stringdist)
+
 
 f <- function(strings) {
   if(length(strings)==1) return(rep(0, length(strings)))

--- a/tmd/areas/targets/prepare/prepare_states/construct_soi_documentation.qmd
+++ b/tmd/areas/targets/prepare/prepare_states/construct_soi_documentation.qmd
@@ -4,7 +4,7 @@ editor_options:
  chunk_output_type: console
 ---
 
-# Clean up SOI documentation files
+# Prepare SOI documentation files
 
 ## Setup
 
@@ -19,14 +19,15 @@ library(stringdist) # for calculating "distances" between strings
 
 ```
 
-## Read, stack, and save the documentation data
 
-### Read and stack documentation files for different years
+## Read and stack documentation files for multiple years
 
-Start with *soi_states_variable_documentation.xlsx*, a hand-created workbook that has a sheet for each year from 2015-2021. Each sheet has a table from the SOI documentation file for that year, with variable names, variable descriptions, and certain other information. For example, the SOI file for 2021 is named *21incmdocguide.doc*. 
+Start with *soi_states_variable_documentation.xlsx*, a hand-created workbook that has a sheet for each year from 2015-2021. Each sheet has a table from the SOI documentation file for that year, with variable names, variable descriptions, and certain other information. For example, the SOI file for 2021 is named *21incmdocguide.doc*. See the notes sheet in the workbook for how the Word tables were copied to Excel. The basic idea was to copy each table to a sheet and make the absolute minimum manual changes needed to make the table rectangular and computer-readable. The goal is to do as much parsing and cleaning in computer code as possible to reduce risk of errors and make it reproducible.
 
-See the notes sheet in the workbook for how the Word tables were copied to Excel. The basic idea was to copy each table to a sheet and make the absolute minimum manual changes needed to make the table rectangular and computer-readable. The goal is to do as much parsing and cleaning in computer code as possible to reduce risk of errors and make it reproducible.
-
+Read each sheet (one per year).
+Drop empty rows.
+Combine multiple rows for the AGI_STUB variable into one row that has information on AGI ranges.
+Stack the years.
 
 ```{r}
 #| label: stack-documentation
@@ -35,7 +36,7 @@ See the notes sheet in the workbook for how the Word tables were copied to Excel
 fname <- "soi_states_variable_documentation.xlsx"
 fpath <- fs::path(DRAW, fname)
 
-f <- function(year){
+get_year <- function(year){
   df1 <- readxl::read_xlsx(fpath, sheet = as.character(year), col_types = "text")
   df2 <- df1 |> 
     select(vname=1, description=2, reference=3, type=4) |> 
@@ -53,65 +54,94 @@ f <- function(year){
   df2
 }
 
-# f(2021)
-# f(2020)
-# f(2019)
-# f(2018)
-# f(2017)
-# f(2016)
-# f(2015)
+# get_year(2021)
+# get_year(2020)
+# get_year(2019)
+# get_year(2018)
+# get_year(2017)
+# get_year(2016)
+# get_year(2015)
 
-stacked_docs <- purrr::map(2015:2021, f) |> 
+stacked_docs <- purrr::map(2015:2021, get_year) |> 
   list_rbind()
 
 count(stacked_docs, year)
 
-# write_csv(df, fs::path(DINTERMEDIATE, "soi_documentation.csv"))
 
 ```
 
-```{r}
+## Clean stacked file and make uniform variable descriptions
 
+Variable descriptions change somewhat from year to year, sometimes due to slight changes in what the variable measures, and sometimes for small inconsistencies.
+
+Goals: (1) create a cleaned description for each variable for each year, and (2) create uniform description for each variable that can be used for all years.
+
+Steps:
+
+-   Clean each SOI variable, removing footnotes and other year-specific editorial inconsistencies.
+-   For each variable, calculate a measure of distance between its description in one year and its description in the prior year.
+-   Visually inspect descriptions that have large year-to-year changes
+-   For a small set of variables that have significant changes, prepare new descriptions
+-   Create uniform descriptions:
+    -   for variables with minimal changes, use the latest year
+    -   for variables with larger changes, use the new descriptions
+-   Create and save new files:
+    -   one with descriptions for each year - original descriptions, cleaned descriptions, and uniform descriptions
+    -   one with a single uniform description for each variable
+
+```{r}
+#| label: clean-stacked-documentation
+#| output: false
+
+cleanit <- function(strings) {
+  # remove any footnotes at the end of descriptions when in square brackets
+  #   for example, remove [3] [16, 17] and similar
+  stringr::str_remove(strings, " \\[\\d+(, \\d+)*\\]")
+}
+
+str_distance <- function(strings) {
+  # calculate "distance" between strings - between the description for a variable
+  #   in one year and the previous year
+  if(length(strings)==1) return(rep(0, length(strings)))
+  c(NA_integer_, sapply(2:length(strings), \(i) stringdist::stringdist(strings[i], strings[i - 1], method = "lv")))
+}
 
 # identify variables that have more than one description, and then
 # identify instances where the descriptions are highly dissimilar
 
-
-f <- function(strings) {
-  if(length(strings)==1) return(rep(0, length(strings)))
-  c(NA_integer_, sapply(2:length(strings), \(i) stringdist(strings[i], strings[i - 1], method = "lv")))
-}
-
-distances <- df |> 
+distances <- stacked_docs |> 
   select(year, vname, description) |> 
   arrange(vname, year) |>
   mutate(n=n(),
          nunique=length(unique(description)), 
          .by=vname) |> 
-  # filter(nunique > 1) |> 
-  mutate(distance=f(description), 
+  mutate(cleaned=cleanit(description),
+         distance=str_distance(cleaned), 
          maxdist=max(distance, na.rm=TRUE),
          .by=vname)
+
 count(distances, maxdist)
 
-# analysis
-cleanit <- function(strings) str_remove(strings, " \\[\\d+(, \\d+)*\\]")
-distances |> filter(maxdist == 2) # nothing to worry about, remove ending and keep last
-distances |> filter(maxdist == 3) 
-distances |> filter(maxdist == 4) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 5) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 14) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 17) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 18) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 20) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 30) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 31) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 32) |> mutate(d2=cleanit(description))
-distances |> filter(maxdist == 37) |> mutate(d2=cleanit(description))
+# visually inspect differences to see which descriptions we will need to create manually
+distances |> filter(maxdist == 2) # all good keep latest
+distances |> filter(maxdist == 3) # keep latest
+distances |> filter(maxdist == 4) # A10971, N10971
+distances |> filter(maxdist == 10) # N2
+distances |> filter(maxdist == 14) # A06500, N06500
+distances |> filter(maxdist == 17) # A07180, N07180, N19700
+distances |> filter(maxdist == 18) # A19700
+distances |> filter(maxdist == 20) # A07225, N07225
+distances |> filter(maxdist == 30) # A20950, N20950
+distances |> filter(maxdist == 31) # N11070
+distances |> filter(maxdist == 32) # A11070
+distances |> filter(maxdist == 37) # A11450, N11450
 
 adjusted_descriptions <- read_delim(
 "vname; adjusted
 A00100; Adjusted gross income (AGI) amount
+A10971; Economic impact payment amount (pre-2021 is different)
+N10971; Number of returns with economic impact payment (pre-2021 is different)
+N2; Number of individuals (pre-2018 is different)
 N06500; Number of returns with income tax after credits (pre-2018 is different)
 A06500; Income tax after credits amount (pre-2018 is different)
 A07180; Nonrefundable child care credit amount (pre-2021 is different)
@@ -121,6 +151,7 @@ A19700; Total charitable contributions amount (pre-2017 is different)
 A07225; Nonrefundable child and other dependent tax credit amount (pre-2021 is different)
 N07225; Number of returns with nonrefundable child and other dependent tax credit (pre-2021 is different)
 A20950; Other non-limited miscellaneous deductions amount (pre-2018 is different)
+N20950; Number of returns with Other non-limited miscellaneous deductions (pre-2018 is different)
 N11070; Number of returns with refundable child tax credit or additional child tax credit (pre-2021 is different)
 A11070; Refundable child tax credit or additional child tax credit amount (pre-2021 is different)
 A11450; Qualified sick and family leave credit for leave taken before April 1, 2021 amount (pre-2021 is different)
@@ -129,8 +160,7 @@ N11450; Number of returns with qualified sick and family leave credit for leave 
 adjusted_descriptions
 
 adjusted1 <- distances |> 
-  mutate(cleaned=cleanit(description),
-         last=last(cleaned),
+  mutate(last=last(cleaned),
          .by=vname) |> 
   left_join(adjusted_descriptions,
             by = join_by(vname)) |> 
@@ -138,26 +168,27 @@ adjusted1 <- distances |>
                              adjusted,
                              last))
 
-adjusted2 <- adjusted1 |> 
+cleaned_descriptions <- adjusted1 |> 
   select(year, vname, description, udescription)
 
+```
 
-# strings <- c("Economic impact payment first round amount [16, 17]", "abc [3]")
-# str_remove(strings, " \\[\\d+(, \\d+)*\\]")
-# cleaned_strings <- str_remove(strings, " \\[\\d+\\]")
+## Save files
 
-# install.packages("stringdist")
+```{r}
+#| label: save-files
+#| output: false
 
+write_csv(cleaned_descriptions, fs::path(DINTERMEDIATE, "soi_documentation_by_year.csv"))
 
-# Sample vector of strings
-# strings <- c("apple", "apples", "apples", "apricot", "banana", "bandana", "band")
-# #                         1         0         5         7         1         3
-# f(strings)
-# # Compute the similarity between consecutive elements
-# distances <- sapply(2:length(strings), function(i) stringdist(strings[i], strings[i - 1], method = "lv"))
-# sapply(2:length(strings), \(i) stringdist(strings[i], strings[i - 1], method = "lv"))
-# distances
+uniform_descriptions <- cleaned_descriptions |> 
+  select(vname, udescription) |> 
+  distinct()
 
+# verify only one description per variable
+anyDuplicated(uniform_descriptions$vname)
+
+write_csv(uniform_descriptions, fs::path(DINTERMEDIATE, "soi_documentation.csv"))
 
 ```
 

--- a/tmd/areas/targets/prepare/prepare_states/download_soi_data.qmd
+++ b/tmd/areas/targets/prepare/prepare_states/download_soi_data.qmd
@@ -33,7 +33,18 @@ source(here::here("R", "functions.R"))
 
 ## (Optionally) Download SOI state data and documentation
 
-As noted, by default, the files will NOT be downloaded when the project is rendered.
+As noted, by default, the files will NOT be downloaded when the project is rendered. 
+
+**All necessary files will be in the `raw_data` folder on GitHub and should be available when the repo is cloned.**
+
+The necessary files are shown below. For those that have [yy], [yy] are the trailing 2 digits of the year. The project includes files for 2015-2021:
+
+-   [yy]in54cm.xlsx or similar, from SOI: each file has human-readable SOI values for all states for the year.
+-   [yy]in54cmcsv.csv or similar, from SOI: file with SOI values for all states for the year.
+-   [yy]incmdocguide.doc, from SOI: descriptive documentation, including a table of variables and their descriptions
+-   soi_states_variable_documentation.xlsx, hand-created by project team from the .doc files: has a sheet for each year with its documentation table. **NOT** intended to be edited by users.
+
+Change options for the chunk below to `eval: true` to download files.
 
 ```{r}
 #| label: downloads

--- a/tmd/areas/targets/prepare/prepare_states/get_soi_documentation.qmd
+++ b/tmd/areas/targets/prepare/prepare_states/get_soi_documentation.qmd
@@ -17,10 +17,11 @@ source(here::here("R", "functions.R"))
 
 ```
 
-## Cleaning
+## Read, combine, and save the documentation data
 
 ```{r}
-
+#| label: combine-documentation
+#| output: false
 
 fname <- "soi_states_variable_documentation.xlsx"
 fpath <- fs::path(DRAW, fname)
@@ -43,20 +44,111 @@ df2 <- df1 |>
 df2
 }
 
-f(2021)
-f(2020)
-f(2019)
-f(2018)
-f(2017)
-f(2016)
-f(2015)
+# f(2021)
+# f(2020)
+# f(2019)
+# f(2018)
+# f(2017)
+# f(2016)
+# f(2015)
 
 df <- purrr::map(2015:2021, f) |> 
   list_rbind()
 
 count(df, year)
 
-write_csv(df, fs::path(DINTERMEDIATE, "soi_documentation.csv"))
+# write_csv(df, fs::path(DINTERMEDIATE, "soi_documentation.csv"))
+
+```
+
+```{r}
+
+
+# identify variables that have more than one description, and then
+# identify instances where the descriptions are highly dissimilar
+library(stringdist)
+
+f <- function(strings) {
+  if(length(strings)==1) return(rep(0, length(strings)))
+  c(NA_integer_, sapply(2:length(strings), \(i) stringdist(strings[i], strings[i - 1], method = "lv")))
+}
+
+distances <- df |> 
+  select(year, vname, description) |> 
+  arrange(vname, year) |>
+  mutate(n=n(),
+         nunique=length(unique(description)), 
+         .by=vname) |> 
+  # filter(nunique > 1) |> 
+  mutate(distance=f(description), 
+         maxdist=max(distance, na.rm=TRUE),
+         .by=vname)
+count(distances, maxdist)
+
+# analysis
+cleanit <- function(strings) str_remove(strings, " \\[\\d+(, \\d+)*\\]")
+distances |> filter(maxdist == 2) # nothing to worry about, remove ending and keep last
+distances |> filter(maxdist == 3) 
+distances |> filter(maxdist == 4) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 5) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 14) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 17) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 18) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 20) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 30) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 31) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 32) |> mutate(d2=cleanit(description))
+distances |> filter(maxdist == 37) |> mutate(d2=cleanit(description))
+
+adjusted_descriptions <- read_delim(
+"vname; adjusted
+A00100; Adjusted gross income (AGI) amount
+N06500; Number of returns with income tax after credits (pre-2018 is different)
+A06500; Income tax after credits amount (pre-2018 is different)
+A07180; Nonrefundable child care credit amount (pre-2021 is different)
+N07180; Number of returns with nonrefundable child care credit (pre-2021 is different)
+N19700; Number of returns with Total charitable contributions (pre-2017 is different)
+A19700; Total charitable contributions amount (pre-2017 is different)
+A07225; Nonrefundable child and other dependent tax credit amount (pre-2021 is different)
+N07225; Number of returns with nonrefundable child and other dependent tax credit (pre-2021 is different)
+A20950; Other non-limited miscellaneous deductions amount (pre-2018 is different)
+N11070; Number of returns with refundable child tax credit or additional child tax credit (pre-2021 is different)
+A11070; Refundable child tax credit or additional child tax credit amount (pre-2021 is different)
+A11450; Qualified sick and family leave credit for leave taken before April 1, 2021 amount (pre-2021 is different)
+N11450; Number of returns with qualified sick and family leave credit for leave taken before April 1, 2021 (pre-2021 is different)
+", delim=";", trim_ws=TRUE)
+adjusted_descriptions
+
+adjusted1 <- distances |> 
+  mutate(cleaned=cleanit(description),
+         last=last(cleaned),
+         .by=vname) |> 
+  left_join(adjusted_descriptions,
+            by = join_by(vname)) |> 
+  mutate(udescription=ifelse(!is.na(adjusted),
+                             adjusted,
+                             last))
+
+adjusted2 <- adjusted1 |> 
+  select(year, vname, description, udescription)
+
+
+# strings <- c("Economic impact payment first round amount [16, 17]", "abc [3]")
+# str_remove(strings, " \\[\\d+(, \\d+)*\\]")
+# cleaned_strings <- str_remove(strings, " \\[\\d+\\]")
+
+# install.packages("stringdist")
+
+
+# Sample vector of strings
+# strings <- c("apple", "apples", "apples", "apricot", "banana", "bandana", "band")
+# #                         1         0         5         7         1         3
+# f(strings)
+# # Compute the similarity between consecutive elements
+# distances <- sapply(2:length(strings), function(i) stringdist(strings[i], strings[i - 1], method = "lv"))
+# sapply(2:length(strings), \(i) stringdist(strings[i], strings[i - 1], method = "lv"))
+# distances
+
 
 ```
 

--- a/tmd/areas/targets/prepare/prepare_states/get_soi_documentation.qmd
+++ b/tmd/areas/targets/prepare/prepare_states/get_soi_documentation.qmd
@@ -1,0 +1,62 @@
+---
+output: html_document
+editor_options: 
+ chunk_output_type: console
+---
+
+# Clean up SOI documentation files
+
+## Setup
+
+```{r}
+#| label: setup
+
+source(here::here("R", "libraries.R"))
+source(here::here("R", "constants.R"))
+source(here::here("R", "functions.R"))
+
+```
+
+## Cleaning
+
+```{r}
+
+
+fname <- "soi_states_variable_documentation.xlsx"
+fpath <- fs::path(DRAW, fname)
+
+f <- function(year){
+  df1 <- readxl::read_xlsx(fpath, sheet = as.character(year), col_types = "text")
+df2 <- df1 |> 
+  select(vname=1, description=2, reference=3, type=4) |> 
+  filter(if_any(everything(), ~!is.na(.))) |> 
+  # after verifying that AGI_STUB is the only variable with NA in vname
+  # fill down and then concatenate the reference column
+  fill(vname, description, type, .direction="down") |> 
+  mutate(reference = paste(reference, collapse = "\n"), .by=vname) |> 
+  distinct() |> 
+  # for now, make mistaken references NA
+  mutate(reference=ifelse(!is.na(as.numeric(reference)), NA_character_, reference),
+         reference=ifelse(reference=="NA", NA_character_, reference),
+         year=!!year) |> 
+  relocate(year)
+df2
+}
+
+f(2021)
+f(2020)
+f(2019)
+f(2018)
+f(2017)
+f(2016)
+f(2015)
+
+df <- purrr::map(2015:2021, f) |> 
+  list_rbind()
+
+count(df, year)
+
+write_csv(df, fs::path(DINTERMEDIATE, "soi_documentation.csv"))
+
+```
+

--- a/tmd/areas/targets/prepare/prepare_states/renv.lock
+++ b/tmd/areas/targets/prepare/prepare_states/renv.lock
@@ -102,14 +102,14 @@
     },
     "Rcpp": {
       "Package": "Rcpp",
-      "Version": "1.0.13",
+      "Version": "1.0.13-1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "methods",
         "utils"
       ],
-      "Hash": "f27411eb6d9c3dada5edd444b8416675"
+      "Hash": "6b868847b365672d6c1677b1608da9ed"
     },
     "V8": {
       "Package": "V8",
@@ -406,13 +406,13 @@
     },
     "curl": {
       "Package": "curl",
-      "Version": "5.2.3",
+      "Version": "6.0.1",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "R"
       ],
-      "Hash": "d91263322a58af798f6cf3b13fd56dde"
+      "Hash": "e8ba62486230951fcd2b881c5be23f96"
     },
     "data.table": {
       "Package": "data.table",
@@ -560,7 +560,7 @@
     },
     "fontawesome": {
       "Package": "fontawesome",
-      "Version": "0.5.2",
+      "Version": "0.5.3",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -568,7 +568,7 @@
         "htmltools",
         "rlang"
       ],
-      "Hash": "c2efdd5f0bcd1ea861c2d4e2a883a67d"
+      "Hash": "bd1297f9b5b1fc1372d19e2c4cd82215"
     },
     "forcats": {
       "Package": "forcats",
@@ -936,7 +936,7 @@
     },
     "knitr": {
       "Package": "knitr",
-      "Version": "1.48",
+      "Version": "1.49",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -948,7 +948,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "acf380f300c721da9fde7df115a5f86f"
+      "Hash": "9fcb189926d93c636dea94fbe4f44480"
     },
     "labeling": {
       "Package": "labeling",
@@ -1417,7 +1417,7 @@
     },
     "rmarkdown": {
       "Package": "rmarkdown",
-      "Version": "2.28",
+      "Version": "2.29",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1436,7 +1436,7 @@
         "xfun",
         "yaml"
       ],
-      "Hash": "062470668513dcda416927085ee9bdc7"
+      "Hash": "df99277f63d01c34e95e3d2f06a79736"
     },
     "rprojroot": {
       "Package": "rprojroot",
@@ -1535,7 +1535,7 @@
     },
     "sf": {
       "Package": "sf",
-      "Version": "1.0-18",
+      "Version": "1.0-19",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1554,7 +1554,7 @@
         "units",
         "utils"
       ],
-      "Hash": "801bec14b3bae0f37eef4d187ee0bb44"
+      "Hash": "fe02eec2f6b3ba0e24afe83d5ccfb528"
     },
     "skimr": {
       "Package": "skimr",
@@ -1799,13 +1799,13 @@
     },
     "tinytex": {
       "Package": "tinytex",
-      "Version": "0.53",
+      "Version": "0.54",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
         "xfun"
       ],
-      "Hash": "9db859e8aabbb474293dde3097839420"
+      "Hash": "3ec7e3ddcacc2d34a9046941222bf94d"
     },
     "tzdb": {
       "Package": "tzdb",
@@ -1923,7 +1923,7 @@
     },
     "xfun": {
       "Package": "xfun",
-      "Version": "0.48",
+      "Version": "0.49",
       "Source": "Repository",
       "Repository": "CRAN",
       "Requirements": [
@@ -1932,7 +1932,7 @@
         "stats",
         "tools"
       ],
-      "Hash": "89e455b87c84e227eb7f60a1b4e5fe1f"
+      "Hash": "8687398773806cfff9401a2feca96298"
     },
     "xml2": {
       "Package": "xml2",

--- a/tmd/areas/targets/prepare/prepare_states/renv.lock
+++ b/tmd/areas/targets/prepare/prepare_states/renv.lock
@@ -1580,6 +1580,17 @@
       ],
       "Hash": "8f138ff2c8fbea9e0a523f6c399c0386"
     },
+    "stringdist": {
+      "Package": "stringdist",
+      "Version": "0.9.12",
+      "Source": "Repository",
+      "Repository": "CRAN",
+      "Requirements": [
+        "R",
+        "parallel"
+      ],
+      "Hash": "f360720fa3feb7db9d4133b31ebb067f"
+    },
     "stringi": {
       "Package": "stringi",
       "Version": "1.8.4",

--- a/tmd/areas/targets/prepare/prepare_states/temp.r
+++ b/tmd/areas/targets/prepare/prepare_states/temp.r
@@ -1,0 +1,19 @@
+
+fname <- "soi_states_variable_documentation.xlsx"
+fpath <- fs::path(DRAW, fname)
+
+# df1 <- readxl::read_xlsx(fpath, sheet = "2021", col_types = "list")
+df1 <- readxl::read_xlsx(fpath, sheet = "2021", col_types = "text")
+df2 <- df1 |> 
+  select(vname=1, description=2, reference=3, type=4) |> 
+  filter(if_any(everything(), ~!is.na(.))) |> 
+  # after verifying that AGI_STUB is the only variable with NA in vname
+  # fill down and then concatenate the reference column
+  fill(vname, description, type, .direction="down") |> 
+  mutate(reference = paste(reference, collapse = "\n"), .by=vname) |> 
+  distinct() |> 
+  # for now, make mistaken references NA
+  mutate(reference=ifelse(!is.na(as.numeric(reference)), NA_character_, reference),
+         reference=ifelse(reference=="NA", NA_character_, reference))
+    
+df2


### PR DESCRIPTION
This PR does not change any python code.

This PR prepares csv files with cleaned variable descriptions for each variable in state data from SOI Historical Table 2.

The code creates 2 output files that are saved in the *data/intermediate* folder. These files are not included in the repo. They will be created by the user when the project is rendered:

-  *soi_documentation_by_year.csv* has for each variable, for each year, the SOI description for that year and a uniform description across all years
- *soi_documentation.csv* has for each variable a uniform description that is general enough to apply to all years