### PR TITLE
Add .quarto/ directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ tmd/storage/output/tax_expenditures
 
 # Local Netlify folder
 .netlify
+
+# Quarto output directories
+**/.quarto/


### PR DESCRIPTION
- Ignore all .quarto/ output directories created by Quarto
- Prevents Quarto build artifacts from being accidentally committed

🤖 Generated with [Claude Code](https://claude.ai/code)