### PR TITLE
Update `TMD/results` to reflect bug fix in Tax-Calculator 6.1.1

### DIFF
--- a/results/README.md
+++ b/results/README.md
@@ -5,7 +5,7 @@ different versions of the three TMD input files with the
 Tax-Calculator CLI.  The idea is to make an historical record of how
 2022-2035 results change as the TMD data are updated and improved.
 
-## Using `tmd21-files.zip` input files and Tax-Calculator 6.0.0
+## Using `tmd21-files.zip` input files and Tax-Calculator 6.1.1
 
 The private `tmd21-files.zip` file contains TMD input files generated
 at the end of the 2024 phase that used 2021 IRS statistics as targets.
@@ -15,15 +15,15 @@ After unzipping the `tmd21-files.zip` file in this folder, the
 follows:
 
 ```
-(base) results> tc --version
-Tax-Calculator 6.0.0 on Python 3.12
+(base) results> tc --version              
+Tax-Calculator 6.1.1 on Python 3.13
 
 (base) results> ls -l tmd*csv*
 -rw-r--r--  1 mrh  staff     12611 Feb 11  2025 tmd_growfactors.csv
 -rw-r--r--  1 mrh  staff  52609134 Feb 11  2025 tmd_weights.csv.gz
 -rw-r--r--  1 mrh  staff  60903481 Feb 11  2025 tmd.csv
 
-(base) results> tc tmd.csv 2022 --numyears 14 --exact --tables --runid 21
+(base) results> tc tmd.csv 2022 --numyears 14 --exact --tables --runid 21     
 Read input data for 2021; input data were extrapolated to 2022
 Write tabular output to file run21-22.tables
 Advance input data and policy to 2023
@@ -52,5 +52,5 @@ Advance input data and policy to 2034
 Write tabular output to file run21-34.tables
 Advance input data and policy to 2035
 Write tabular output to file run21-35.tables
-Execution time is 19.2 seconds
+Execution time is 19.3 seconds
 ```

--- a/results/run21-22.tables
+++ b/results/run21-22.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2022
  6    18.47    1286.0      73.5     129.3       0.0     202.8
  7    18.47    1785.6     133.3     180.9       0.0     314.2
  8    18.47    2644.7     252.5     272.3       0.0     524.8
- 9    18.47    9052.4    1744.0     465.9       0.0    2209.9
- A   184.69   17207.1    2187.6    1309.5       0.0    3497.2
+ 9    18.47    9052.4    1744.0     465.9       0.0    2209.8
+ A   184.69   17207.1    2187.6    1309.5       0.0    3497.1
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2022
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-23.tables
+++ b/results/run21-23.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2023
  6    18.63    1366.6      77.2     137.1       0.0     214.3
  7    18.63    1896.2     140.8     191.9       0.0     332.6
  8    18.63    2807.9     266.0     287.8       0.0     553.8
- 9    18.63    9665.4    1864.7     499.8       0.0    2364.5
- A   186.33   18324.2    2328.6    1395.0       0.0    3723.5
+ 9    18.63    9665.4    1864.6     499.8       0.0    2364.4
+ A   186.33   18324.2    2328.5    1395.0       0.0    3723.5
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2023
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-24.tables
+++ b/results/run21-24.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2024
  6    18.85    1441.0      81.2     143.8       0.0     224.9
  7    18.84    1997.6     148.1     201.8       0.0     349.9
  8    18.85    2953.6     278.2     302.0       0.0     580.2
- 9    18.85   10001.7    1912.7     529.2       0.0    2441.8
- A   188.45   19141.8    2397.3    1470.2       0.0    3867.5
+ 9    18.85   10001.7    1912.6     529.2       0.0    2441.8
+ A   188.45   19141.8    2397.2    1470.2       0.0    3867.5
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2024
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-25.tables
+++ b/results/run21-25.tables
@@ -11,7 +11,7 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2025
  7    19.06    2097.4     147.1     211.6       0.0     358.7
  8    19.06    3099.9     280.3     317.7       0.0     598.0
  9    19.06   10413.0    1962.0     558.0       0.0    2520.0
- A   190.62   20015.8    2439.8    1546.3       0.0    3986.0
+ A   190.62   20015.8    2439.7    1546.3       0.0    3986.0
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2025
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-26.tables
+++ b/results/run21-26.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2026
  6    19.25    1581.6      85.5     158.4       0.0     243.9
  7    19.24    2191.6     156.5     221.1       0.0     377.6
  8    19.24    3238.1     298.0     332.3       0.0     630.4
- 9    19.24   10787.3    2063.0     585.2       0.0    2648.2
- A   192.41   20828.5    2576.5    1618.2       0.0    4194.6
+ 9    19.24   10787.3    2063.4     585.2       0.0    2648.6
+ A   192.41   20828.5    2576.9    1618.2       0.0    4195.1
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2026
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-27.tables
+++ b/results/run21-27.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2027
  6    19.38    1645.7      90.7     164.9       0.0     255.5
  7    19.38    2280.5     164.7     229.9       0.0     394.7
  8    19.38    3368.5     313.2     344.7       0.0     658.0
- 9    19.38   11160.4    2134.8     611.7       0.0    2746.5
- A   193.77   21614.0    2679.1    1685.4       0.0    4364.5
+ 9    19.38   11160.4    2135.2     611.7       0.0    2746.9
+ A   193.77   21614.0    2679.6    1685.4       0.0    4365.0
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2027
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-28.tables
+++ b/results/run21-28.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2028
  6    19.47    1708.9      96.0     171.0       0.0     267.0
  7    19.47    2367.5     173.0     238.9       0.0     411.9
  8    19.47    3496.7     328.9     357.4       0.0     686.3
- 9    19.47   11548.7    2212.5     635.7       0.0    2848.2
- A   194.72   22405.4    2788.9    1750.1       0.0    4539.0
+ 9    19.47   11548.7    2213.0     635.7       0.0    2848.7
+ A   194.72   22405.4    2789.4    1750.1       0.0    4539.5
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2028
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-29.tables
+++ b/results/run21-29.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2029
  6    19.57    1774.8     106.3     177.5       0.0     283.8
  7    19.56    2458.8     187.2     248.1       0.0     435.3
  8    19.57    3630.7     352.5     371.1       0.0     723.6
- 9    19.57   11968.2    2301.1     660.6       0.0    2961.7
- A   195.66   23244.4    2932.7    1817.6       0.0    4750.3
+ 9    19.57   11968.2    2301.6     660.6       0.0    2962.2
+ A   195.66   23244.4    2933.2    1817.6       0.0    4750.8
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2029
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-30.tables
+++ b/results/run21-30.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2030
  6    19.66    1843.0     112.7     184.1       0.0     296.8
  7    19.66    2553.6     197.4     257.7       0.0     455.1
  8    19.66    3769.5     374.3     384.9       0.0     759.2
- 9    19.66   12404.0    2416.8     686.0       0.0    3102.8
- A   196.58   24116.3    3090.8    1887.1       0.0    4977.9
+ 9    19.66   12404.0    2417.3     686.0       0.0    3103.3
+ A   196.58   24116.3    3091.3    1887.1       0.0    4978.4
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2030
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-31.tables
+++ b/results/run21-31.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2031
  6    19.75    1913.9     119.2     191.0       0.0     310.2
  7    19.75    2651.4     207.0     267.5       0.0     474.5
  8    19.75    3913.8     393.0     399.4       0.0     792.5
- 9    19.75   12856.7    2511.2     711.3       0.0    3222.6
- A   197.48   25021.2    3224.1    1957.9       0.0    5182.0
+ 9    19.75   12856.7    2511.8     711.3       0.0    3223.1
+ A   197.48   25021.2    3224.6    1957.9       0.0    5182.6
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2031
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-32.tables
+++ b/results/run21-32.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2032
  6    19.84    1986.1     126.0     197.7       0.0     323.8
  7    19.83    2751.1     216.8     277.4       0.0     494.2
  8    19.84    4061.2     412.2     413.9       0.0     826.1
- 9    19.84   13328.8    2610.7     737.2       0.0    3347.8
- A   198.35   25953.9    3363.7    2029.9       0.0    5393.6
+ 9    19.84   13328.8    2611.2     737.2       0.0    3348.4
+ A   198.35   25953.9    3364.2    2029.9       0.0    5394.1
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2032
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-33.tables
+++ b/results/run21-33.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2033
  6    19.93    2060.9     132.7     205.0       0.0     337.7
  7    19.91    2852.2     226.8     287.0       0.0     513.8
  8    19.93    4212.2     431.9     428.5       0.0     860.3
- 9    19.92   13810.6    2712.2     763.5       0.0    3475.7
- A   199.21   26906.6    3506.0    2103.1       0.0    5609.0
+ 9    19.92   13810.6    2712.7     763.5       0.0    3476.2
+ A   199.21   26906.6    3506.5    2103.1       0.0    5609.6
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2033
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-34.tables
+++ b/results/run21-34.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2034
  6    20.00    2135.5     139.6     212.2       0.0     351.8
  7    20.00    2957.5     237.2     297.4       0.0     534.6
  8    20.00    4363.8     452.0     443.1       0.0     895.1
- 9    20.00   14305.0    2816.7     790.0       0.0    3606.7
- A   200.03   27880.3    3652.5    2177.3       0.0    5829.8
+ 9    20.00   14305.0    2817.2     790.0       0.0    3607.2
+ A   200.03   27880.3    3653.0    2177.3       0.0    5830.3
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2034
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax

--- a/results/run21-35.tables
+++ b/results/run21-35.tables
@@ -10,8 +10,8 @@ Weighted Tax Reform Totals by Baseline Expanded-Income Decile for 2035
  6    20.08    2213.5     146.9     219.8       0.0     366.8
  7    20.08    3064.8     247.9     308.1       0.0     556.0
  8    20.08    4520.9     472.9     458.4       0.0     931.3
- 9    20.08   14815.2    2924.7     816.9       0.0    3741.6
- A   200.83   28884.5    3804.4    2253.9       0.0    6058.2
+ 9    20.08   14815.2    2925.2     816.9       0.0    3742.2
+ A   200.83   28884.5    3804.9    2253.9       0.0    6058.8
 
 Weighted Tax Differences by Baseline Expanded-Income Decile for 2035
     Returns    ExpInc    IncTax    PayTax     LSTax    AllTax


### PR DESCRIPTION
Tax-Calculator 6.1.1 fixed a misspecification in the value of a current-law policy parameter,, which caused some changes in the `results/*.tables`.
