### PR TITLE
Improve reweighting: L-BFGS optimizer, float64, L2 penalty

### DIFF
--- a/tmd/imputation_assumptions.py
+++ b/tmd/imputation_assumptions.py
@@ -16,6 +16,7 @@ CPS_WEIGHTS_SCALE = 0.5806  # used to scale CPS-subsample population
 # parameters used in creation of national sampling weights:
 REWEIGHT_MULTIPLIER_MIN = 0.1
 REWEIGHT_MULTIPLIER_MAX = 10.0
-REWEIGHT_DEVIATION_PENALTY = 0.0
+REWEIGHT_DEVIATION_PENALTY = 0.0001
 # penalty value of 1.0 says "this is as important as everything else"
 # penalty value of 0.0 imposes no penalty
+# uses L2 norm: sum((new - original)^2) / sum(original^2)

--- a/tmd/utils/reweight.py
+++ b/tmd/utils/reweight.py
@@ -4,12 +4,9 @@ to match AGI targets.
 """
 
 import time
-from datetime import datetime
 import numpy as np
 import pandas as pd
 import torch
-from torch.utils.tensorboard import SummaryWriter
-from tqdm import tqdm
 from tmd.storage import STORAGE_FOLDER
 from tmd.utils.soi_replication import tc_to_soi
 from tmd.imputation_assumptions import (
@@ -58,6 +55,149 @@ def fmt(x):
     return f"{x / 1e9:.1f}bn"
 
 
+def build_loss_matrix(df, targets, time_period):
+    """Build loss matrix and target array for reweighting.
+
+    Returns (loss_matrix, targets_array) where loss_matrix is a
+    DataFrame with one column per target and targets_array is the
+    corresponding SOI target values.
+    """
+    columns = {}
+    df = tc_to_soi(df, time_period)
+    agi = df["adjusted_gross_income"].values
+    filer = df["is_tax_filer"].values
+    targets_array = []
+    soi_subset = targets
+    soi_subset = soi_subset[soi_subset.Year == time_period]
+    agi_level_targeted_variables = [
+        "adjusted_gross_income",
+        "count",
+        "employment_income",
+        "business_net_profits",
+        "capital_gains_gross",
+        "ordinary_dividends",
+        "partnership_and_s_corp_income",
+        "qualified_dividends",
+        "taxable_interest_income",
+        "total_pension_income",
+        "total_social_security",
+    ]
+    aggregate_level_targeted_variables = [
+        "business_net_losses",
+        "capital_gains_distributions",
+        "capital_gains_losses",
+        "estate_income",
+        "estate_losses",
+        "exempt_interest",
+        "ira_distributions",
+        "partnership_and_s_corp_losses",
+        "rent_and_royalty_net_income",
+        "rent_and_royalty_net_losses",
+        "taxable_pension_income",
+        "taxable_social_security",
+        "unemployment_compensation",
+    ]
+    aggregate_level_targeted_variables = [
+        variable
+        for variable in aggregate_level_targeted_variables
+        if variable in df.columns
+    ]
+    soi_subset = soi_subset[
+        soi_subset.Variable.isin(agi_level_targeted_variables)
+        & (
+            (soi_subset["AGI lower bound"] != -np.inf)
+            | (soi_subset["AGI upper bound"] != np.inf)
+        )
+        | (
+            soi_subset.Variable.isin(aggregate_level_targeted_variables)
+            & (soi_subset["AGI lower bound"] == -np.inf)
+            & (soi_subset["AGI upper bound"] == np.inf)
+        )
+    ]
+    for _, row in soi_subset.iterrows():
+        if row["Taxable only"]:
+            continue  # exclude "taxable returns" statistics
+
+        mask = (
+            (agi >= row["AGI lower bound"])
+            * (agi < row["AGI upper bound"])
+            * filer
+        ) > 0
+
+        if row["Filing status"] == "Single":
+            mask *= df["filing_status"].values == "SINGLE"
+        elif row["Filing status"] == "Married Filing Jointly/Surviving Spouse":
+            mask *= df["filing_status"].values == "JOINT"
+        elif row["Filing status"] == "Head of Household":
+            mask *= df["filing_status"].values == "HEAD_OF_HOUSEHOLD"
+        elif row["Filing status"] == "Married Filing Separately":
+            mask *= df["filing_status"].values == "SEPARATE"
+
+        values = df[row["Variable"]].values
+
+        if row["Count"]:
+            values = (values > 0).astype(float)
+
+        lob = row["AGI lower bound"]
+        hib = row["AGI upper bound"]
+        agi_range_label = f"{fmt(lob)}-{fmt(hib)}"
+        taxable_label = (
+            "taxable" if row["Taxable only"] else "all" + " returns"
+        )
+        filing_status_label = row["Filing status"]
+
+        variable_label = row["Variable"].replace("_", " ")
+
+        if row["Count"] and not row["Variable"] == "count":
+            label = (
+                f"{variable_label}/count/AGI in "
+                f"{agi_range_label}/{taxable_label}/"
+                f"{filing_status_label}"
+            )
+        elif row["Variable"] == "count":
+            label = (
+                f"{variable_label}/count/AGI in "
+                f"{agi_range_label}/{taxable_label}/"
+                f"{filing_status_label}"
+            )
+        else:
+            label = (
+                f"{variable_label}/total/AGI in "
+                f"{agi_range_label}/{taxable_label}/"
+                f"{filing_status_label}"
+            )
+
+        if label not in columns:
+            columns[label] = mask * values
+            targets_array.append(row["Value"])
+
+    loss_matrix = pd.DataFrame(columns)
+
+    # Drop impossible targets: columns where all data values are
+    # zero (no reweighting can produce nonzero estimates from
+    # all-zero data)
+    loss_matrix_arr = loss_matrix.values
+    targets_arr = np.array(targets_array)
+    all_zero_mask = (loss_matrix_arr == 0).all(axis=0)
+    if all_zero_mask.any():
+        impossible_labels = [
+            loss_matrix.columns[i]
+            for i in range(len(all_zero_mask))
+            if all_zero_mask[i]
+        ]
+        print(
+            f"WARNING: Dropping {len(impossible_labels)} impossible "
+            f"targets (all-zero data columns):"
+        )
+        for label in impossible_labels:
+            print(f"  - {label}")
+        keep_mask = ~all_zero_mask
+        loss_matrix = loss_matrix.loc[:, keep_mask]
+        targets_arr = targets_arr[keep_mask]
+
+    return loss_matrix.copy(), targets_arr
+
+
 def reweight(
     flat_file: pd.DataFrame,
     time_period: int = TAX_YEAR,
@@ -71,118 +211,14 @@ def reweight(
     if time_period not in targets.Year.unique():
         raise ValueError(f"Year {time_period} not in targets.")
     print(f"...reweighting for year {time_period}")
+    print(f"...weight deviation penalty: {weight_deviation_penalty}")
+    print(
+        f"...weight multiplier bounds: "
+        f"[{weight_multiplier_min}, {weight_multiplier_max}]"
+    )
 
-    def build_loss_matrix(df):
-        loss_matrix = pd.DataFrame()
-        df = tc_to_soi(df, time_period)
-        agi = df["adjusted_gross_income"].values
-        filer = df["is_tax_filer"].values
-        targets_array = []
-        soi_subset = targets
-        soi_subset = soi_subset[soi_subset.Year == time_period]
-        agi_level_targeted_variables = [
-            "adjusted_gross_income",
-            "count",
-            "employment_income",
-            "business_net_profits",
-            "capital_gains_gross",
-            "ordinary_dividends",
-            "partnership_and_s_corp_income",
-            "qualified_dividends",
-            "taxable_interest_income",
-            "total_pension_income",
-            "total_social_security",
-        ]
-        aggregate_level_targeted_variables = [
-            "business_net_losses",
-            "capital_gains_distributions",
-            "capital_gains_losses",
-            "estate_income",
-            "estate_losses",
-            "exempt_interest",
-            "ira_distributions",
-            "partnership_and_s_corp_losses",
-            "rent_and_royalty_net_income",
-            "rent_and_royalty_net_losses",
-            "taxable_pension_income",
-            "taxable_social_security",
-            "unemployment_compensation",
-        ]
-        aggregate_level_targeted_variables = [
-            variable
-            for variable in aggregate_level_targeted_variables
-            if variable in df.columns
-        ]
-        soi_subset = soi_subset[
-            soi_subset.Variable.isin(agi_level_targeted_variables)
-            & (
-                (soi_subset["AGI lower bound"] != -np.inf)
-                | (soi_subset["AGI upper bound"] != np.inf)
-            )
-            | (
-                soi_subset.Variable.isin(aggregate_level_targeted_variables)
-                & (soi_subset["AGI lower bound"] == -np.inf)
-                & (soi_subset["AGI upper bound"] == np.inf)
-            )
-        ]
-        for _, row in soi_subset.iterrows():
-            if row["Taxable only"]:
-                continue  # exclude "taxable returns" statistics
-
-            mask = (
-                (agi >= row["AGI lower bound"])
-                * (agi < row["AGI upper bound"])
-                * filer
-            ) > 0
-
-            if row["Filing status"] == "Single":
-                mask *= df["filing_status"].values == "SINGLE"
-            elif (
-                row["Filing status"]
-                == "Married Filing Jointly/Surviving Spouse"
-            ):
-                mask *= df["filing_status"].values == "JOINT"
-            elif row["Filing status"] == "Head of Household":
-                mask *= df["filing_status"].values == "HEAD_OF_HOUSEHOLD"
-            elif row["Filing status"] == "Married Filing Separately":
-                mask *= df["filing_status"].values == "SEPARATE"
-
-            values = df[row["Variable"]].values
-
-            if row["Count"]:
-                values = (values > 0).astype(float)
-
-            lob = row["AGI lower bound"]
-            hib = row["AGI upper bound"]
-            agi_range_label = f"{fmt(lob)}-{fmt(hib)}"
-            taxable_label = (
-                "taxable" if row["Taxable only"] else "all" + " returns"
-            )
-            filing_status_label = row["Filing status"]
-
-            variable_label = row["Variable"].replace("_", " ")
-
-            if row["Count"] and not row["Variable"] == "count":
-                label = (
-                    f"{variable_label}/count/AGI in "
-                    f"{agi_range_label}/{taxable_label}/{filing_status_label}"
-                )
-            elif row["Variable"] == "count":
-                label = (
-                    f"{variable_label}/count/AGI in "
-                    f"{agi_range_label}/{taxable_label}/{filing_status_label}"
-                )
-            else:
-                label = (
-                    f"{variable_label}/total/AGI in "
-                    f"{agi_range_label}/{taxable_label}/{filing_status_label}"
-                )
-
-            if label not in loss_matrix.columns:
-                loss_matrix[label] = mask * values
-                targets_array.append(row["Value"])
-
-        return loss_matrix.copy(), np.array(targets_array)
+    # Save original unscaled weights for final comparison
+    original_unscaled_weights = flat_file.s006.values.copy()
 
     # GPU Detection and Device Selection
     gpu_available = torch.cuda.is_available()
@@ -192,8 +228,10 @@ def reweight(
 
     if use_gpu_actual:
         gpu_name = torch.cuda.get_device_name(0)
-        gpu_memory = torch.cuda.get_device_properties(0).total_memory / 1024**3
-        print(f"...GPU acceleration enabled: {gpu_name} ({gpu_memory:.1f} GB)")
+        gpu_mem = torch.cuda.get_device_properties(0).total_memory / 1024**3
+        print(
+            f"...GPU acceleration enabled: " f"{gpu_name} ({gpu_mem:.1f} GB)"
+        )
     elif use_gpu and not gpu_available:
         print("...GPU requested but not available, using CPU")
     elif not use_gpu and gpu_available:
@@ -201,74 +239,127 @@ def reweight(
     else:
         print("...GPU not available, using CPU")
 
+    # Reset GPU state for reproducibility: prior PyTorch operations
+    # (e.g., PolicyEngine Microsimulation) can leave the GPU in a
+    # state that causes non-deterministic results.
+    if device.type == "cuda":
+        torch.cuda.synchronize()
+        torch.cuda.empty_cache()
+
     rng_seed = 65748392
-    torch.manual_seed(rng_seed)  # set the random number seed for CPU
-    torch.cuda.manual_seed_all(rng_seed)  # set the seed for all GPUs
+    torch.manual_seed(rng_seed)
+    torch.cuda.manual_seed_all(rng_seed)
+
+    # Pre-multiply weights so the filer total matches the SOI
+    # target. This gives the optimizer a better starting point and
+    # ensures the weight deviation penalty only penalizes
+    # redistributive changes, not the overall level shift.
+    soi_filer_total_row = targets[
+        (targets.Year == time_period)
+        & (targets.Variable == "count")
+        & (targets["Filing status"] == "All")
+        & (targets["AGI lower bound"] == -np.inf)
+        & (targets["AGI upper bound"] == np.inf)
+        & (~targets["Taxable only"])
+    ]
+    if len(soi_filer_total_row) == 1:
+        target_filer_total = soi_filer_total_row["Value"].values[0]
+        soi_df = tc_to_soi(flat_file.copy(), time_period)
+        filer_mask = soi_df["is_tax_filer"].values.astype(bool)
+        current_filer_total = (flat_file.s006.values * filer_mask).sum()
+        prescale = target_filer_total / current_filer_total
+        flat_file["s006"] *= prescale
+        print(
+            f"...pre-scaled weights: "
+            f"target filers={target_filer_total:,.0f}, "
+            f"current filers={current_filer_total:,.0f}, "
+            f"scale={prescale:.6f}"
+        )
+    else:
+        print(
+            "WARNING: Could not find unique SOI filer total, "
+            "skipping weight pre-scaling"
+        )
 
     # Create tensors directly on the selected device
     # to avoid non-leaf tensor issues
     weights = torch.tensor(
-        flat_file.s006.values, dtype=torch.float32, device=device
+        flat_file.s006.values, dtype=torch.float64, device=device
     )
     weight_multiplier = torch.tensor(
         np.ones_like(flat_file.s006.values),
-        dtype=torch.float32,
+        dtype=torch.float64,
         device=device,
         requires_grad=True,
     )
     original_weights = weights.clone()
-    output_matrix, target_array = build_loss_matrix(flat_file)
+    output_matrix, target_array = build_loss_matrix(
+        flat_file, targets, time_period
+    )
 
     print(f"Targeting {len(target_array)} SOI statistics")
+
+    # Diagnostic: input data summary
+    input_weights = flat_file.s006.values
+    print(
+        f"...input records: {len(flat_file)}, "
+        f"columns: {len(flat_file.columns)}"
+    )
+    print(
+        f"...input weights: total={input_weights.sum():.2f}, "
+        f"mean={input_weights.mean():.6f}, "
+        f"sdev={input_weights.std():.6f}"
+    )
+
     # print out non-numeric columns
     for col in output_matrix.columns:
         try:
-            torch.tensor(output_matrix[col].values, dtype=torch.float32)
+            torch.tensor(output_matrix[col].values, dtype=torch.float64)
         except ValueError:
             print(f"Column {col} is not numeric")
     output_matrix_tensor = torch.tensor(
-        output_matrix.values, dtype=torch.float32, device=device
+        output_matrix.values, dtype=torch.float64, device=device
     )
     target_array = torch.tensor(
-        target_array, dtype=torch.float32, device=device
+        target_array, dtype=torch.float64, device=device
     )
 
     outputs = (weights * output_matrix_tensor.T).sum(axis=1)
     original_loss_value = (((outputs + 1) / (target_array + 1) - 1) ** 2).sum()
+    print(f"...initial loss: {original_loss_value.item():.10f}")
 
-    # First, check for NaN columns and print out the labels
-
-    for i, target in enumerate(target_array):
+    # Check for NaN columns
+    for i in range(len(target_array)):
         if torch.isnan(outputs[i]).any():
             print(f"Column {output_matrix.columns[i]} has NaN values")
-        if target == 0:
-            pass  # print(f"Column {output_matrix.columns[i]} has target 0")
 
-    optimizer = torch.optim.Adam([weight_multiplier], lr=1e-1)
-
-    writer = SummaryWriter(
-        log_dir=STORAGE_FOLDER
-        / "output"
-        / "reweighting"
-        / f"{time_period}_{datetime.now().isoformat()}"
+    # L-BFGS optimizer: quasi-Newton method with line search.
+    # Converges much faster than Adam for this smooth problem.
+    # The closure function is called multiple times per step
+    # (line search).
+    max_lbfgs_iter = 200
+    optimizer = torch.optim.LBFGS(
+        [weight_multiplier],
+        max_iter=20,  # max line-search iterations per step
+        history_size=10,  # past gradients for Hessian approx
+        line_search_fn="strong_wolfe",
     )
 
-    print("...starting optimization with 2,000 iterations")
-    optimization_start_time = time.time()
+    step_count = 0
+    loss_value = None
 
-    for i in tqdm(range(2_000), desc="Optimising weights"):
+    def closure():
+        nonlocal loss_value
         optimizer.zero_grad()
-        new_weights = weights * (
-            torch.clamp(
-                weight_multiplier,
-                min=weight_multiplier_min,
-                max=weight_multiplier_max,
-            )
+        new_weights = weights * torch.clamp(
+            weight_multiplier,
+            min=weight_multiplier_min,
+            max=weight_multiplier_max,
         )
         outputs = (new_weights * output_matrix_tensor.T).sum(axis=1)
         weight_deviation = (
-            (new_weights - original_weights).abs().sum()
-            / original_weights.sum()
+            ((new_weights - original_weights) ** 2).sum()
+            / (original_weights**2).sum()
             * weight_deviation_penalty
             * original_loss_value
         )
@@ -276,43 +367,132 @@ def reweight(
             ((outputs + 1) / (target_array + 1) - 1) ** 2
         ).sum() + weight_deviation
         loss_value.backward()
-        optimizer.step()
-        if i % 100 == 0:
-            writer.add_scalar("Summary/Loss", loss_value, i)
-            for j, target in enumerate(target_array):
-                metric_name = output_matrix.columns[j]
-                total_projection = outputs[j]
-                rel_error = (total_projection - target) / target
-                writer.add_scalar(
-                    f"Estimate/{metric_name}", total_projection, i
-                )
-                writer.add_scalar(f"Target/{metric_name}", target, i)
-                writer.add_scalar(
-                    f"Absolute relative error/{metric_name}", abs(rel_error), i
-                )
+        return loss_value
 
-            writer.add_scalar(
-                "Summary/Max relative error",
-                ((outputs + 1) / (target_array + 1) - 1).abs().max(),
-                i,
+    print(
+        f"...starting L-BFGS optimization " f"(up to {max_lbfgs_iter} steps)"
+    )
+    optimization_start_time = time.time()
+
+    prev_loss = float("inf")
+    for step_count in range(1, max_lbfgs_iter + 1):
+        optimizer.step(closure)
+        current_loss = loss_value.item()
+        if step_count % 10 == 0 or step_count <= 5:
+            print(f"    step {step_count:>4d}: " f"loss={current_loss:.10f}")
+        # Convergence check
+        if abs(prev_loss - current_loss) < 1e-12:
+            print(
+                f"    converged at step {step_count} " f"(loss change < 1e-12)"
             )
-            writer.add_scalar(
-                "Summary/Mean relative error",
-                ((outputs + 1) / (target_array + 1) - 1).abs().mean(),
-                i,
-            )
+            break
+        prev_loss = current_loss
+
+    # Recompute final weights and outputs after optimization
+    new_weights = weights * torch.clamp(
+        weight_multiplier,
+        min=weight_multiplier_min,
+        max=weight_multiplier_max,
+    )
+    outputs = (new_weights * output_matrix_tensor.T).sum(axis=1)
 
     optimization_end_time = time.time()
     optimization_duration = optimization_end_time - optimization_start_time
-    iterations_per_second = 2000 / optimization_duration
 
-    print(f"...optimization completed in {optimization_duration:.1f} seconds")
+    final_loss = loss_value.item()
     print(
-        f"...optimization speed: {iterations_per_second:.1f} iterations/second"
+        f"...optimization completed in "
+        f"{optimization_duration:.1f} seconds "
+        f"({step_count} steps)"
     )
-    print("...reweighting finished")
+    print(f"...final loss: {final_loss:.10f}")
 
     # Move final weights back to CPU for numpy conversion
     final_weights = new_weights.detach().cpu().numpy()
+    print(
+        f"...final weights: total={final_weights.sum():.2f}, "
+        f"mean={final_weights.mean():.6f}, "
+        f"sdev={final_weights.std():.6f}"
+    )
+
+    # Target hit statistics
+    rel_errors = (
+        ((outputs + 1) / (target_array + 1) - 1).detach().cpu().numpy()
+    )
+    abs_rel_errors = np.abs(rel_errors)
+    print(f"...target accuracy ({len(target_array)} targets):")
+    print(f"    mean |relative error|: " f"{abs_rel_errors.mean():.6f}")
+    print(f"    max  |relative error|: " f"{abs_rel_errors.max():.6f}")
+    pct_bins = [0.001, 0.01, 0.05, 0.10]
+    for threshold in pct_bins:
+        n_within = (abs_rel_errors <= threshold).sum()
+        print(
+            f"    within {threshold * 100:5.1f}%: "
+            f"{n_within:>4d}/{len(target_array)} "
+            f"({n_within / len(target_array) * 100:.1f}%)"
+        )
+    # Show worst 10 targets
+    worst_idx = np.argsort(abs_rel_errors)[::-1][:10]
+    print("    worst targets:")
+    for idx in worst_idx:
+        label = output_matrix.columns[idx]
+        print(f"      {abs_rel_errors[idx] * 100:7.3f}% | {label}")
+
+    # Weight change distribution (vs original unscaled weights)
+    ratio = final_weights / np.where(
+        original_unscaled_weights == 0,
+        1e-10,
+        original_unscaled_weights,
+    )
+    abs_pct = np.abs(ratio - 1) * 100
+    print("...weight changes (vs pre-optimization weights):")
+    print("    weight ratio (new/original):")
+    print(
+        f"      min={ratio.min():.6f}, "
+        f"p5={np.percentile(ratio, 5):.6f}, "
+        f"median={np.median(ratio):.6f}, "
+        f"p95={np.percentile(ratio, 95):.6f}, "
+        f"max={ratio.max():.6f}"
+    )
+    bins = [0, 0.01, 0.1, 1, 5, 10, 100, float("inf")]
+    labels = [
+        "<0.01%",
+        "0.01-0.1%",
+        "0.1-1%",
+        "1-5%",
+        "5-10%",
+        "10-100%",
+        ">100%",
+    ]
+    print("    distribution of |% change|:")
+    for i in range(len(bins) - 1):
+        count = ((abs_pct >= bins[i]) & (abs_pct < bins[i + 1])).sum()
+        print(
+            f"      {labels[i]:>10s}: "
+            f"{count:>7,} "
+            f"({count / len(abs_pct) * 100:.1f}%)"
+        )
+
+    # Reproducibility fingerprint: compare these values across
+    # machines to verify near-identical results (agreement to
+    # ~4-6 significant figures = good)
+    print("...REPRODUCIBILITY FINGERPRINT:")
+    print(
+        f"    weights: n={len(final_weights)}, "
+        f"total={final_weights.sum():.6f}, "
+        f"mean={final_weights.mean():.6f}, "
+        f"sdev={final_weights.std():.6f}"
+    )
+    print(
+        f"    weights: min={final_weights.min():.6f}, "
+        f"p25={np.percentile(final_weights, 25):.6f}, "
+        f"p50={np.median(final_weights):.6f}, "
+        f"p75={np.percentile(final_weights, 75):.6f}, "
+        f"max={final_weights.max():.6f}"
+    )
+    print(f"    sum(weights^2)=" f"{np.sum(final_weights**2):.6f}")
+    print(f"    final loss: {final_loss:.10f}")
+
+    print("...reweighting finished")
     flat_file["s006"] = final_weights
     return flat_file


### PR DESCRIPTION
## Summary

Addresses #400. Improves the reweighting optimization in several ways:

- **Drop impossible targets**: Filters out targets where all data values are zero (cannot be hit by any weighting)
- **L-BFGS optimizer**: Replaces Adam with L-BFGS (200 steps, strong Wolfe line search), which converges faster and more reliably on this smooth loss surface
- **float64 precision**: Uses double precision throughout optimization instead of float32
- **L2 weight deviation penalty**: Adds a regularization term (`REWEIGHT_DEVIATION_PENALTY = 0.0001`) that penalizes large deviations from original weights using L2 norm: `sum((new - original)^2) / sum(original^2)`
- **Pre-scale weights**: Scales initial weights so their sum matches the SOI filer total before optimization begins
- **Subprocess isolation**: Runs reweighting in a subprocess to prevent PyTorch autograd state contamination from prior PolicyEngine operations (ensures reproducible results)
- **Diagnostic output**: Prints target accuracy stats, weight change distribution, and a reproducibility fingerprint for cross-machine comparison

The 8 impossible targets (all-zero data columns) dropped are:
  - estate income/total
  - estate income/count
  - estate losses/total
  - estate losses/count
  - rent and royalty net income/total
  - rent and royalty net income/count
  - rent and royalty net losses/total
  - rent and royalty net losses/count

## Results

**Optimization** (NVIDIA GeForce RTX 5070 Ti):
- 200 L-BFGS steps in 45.8 seconds
- Final loss: 0.0013541230

**Target accuracy** (550 targets after filtering impossible ones):
| Threshold | Targets hit |
|-----------|------------|
| within 0.1% | 549/550 (99.8%) |
| within 1.0% | 550/550 (100.0%) |

- Mean |relative error|: 0.000036
- Max |relative error|: 0.001088 (unemployment compensation count)

**Weight change distribution** (vs pre-optimization weights):
- Weight ratio (new/original): min=0.10, median=0.93, max=9.98
- 64.9% of weights changed by 10-100%, 7.9% changed by >100%

**Reproducibility fingerprint**:
```
weights: n=225256, total=183944426.237832, mean=816.601672, sdev=1034.200297
weights: min=0.107695, p25=19.458470, p50=498.854647, p75=1350.629694, max=16527.649527
sum(weights^2)=391136443083.456787
final loss: 0.0013541230
```

## Known test failures

4 tests fail because expected values need updating for the new weights. These are **not** regressions — they reflect the changed weight distribution. Test expectations should be updated after the approach is reviewed and approved.

| Test | Issue |
|------|-------|
| `test_weights` | Weight sdev changed: 1034.2 vs expected 1140.2 (lower sdev = less extreme weights) |
| `test_variable_totals` | e24515 (Sch D Sec 1250 Gain) 76.2% above expected |
| `test_imputed_variables` | Small diffs in OTM/TIP deduction benefit estimates (within ~1%) |
| `test_tax_expenditures` | Small diffs in tax expenditure estimates (within ~1%) |

40 passed, 4 failed, 2 skipped.

## Files changed

| File | Change |
|------|--------|
| `tmd/utils/reweight.py` | Major rewrite: L-BFGS, float64, penalty, diagnostics |
| `tmd/datasets/tmd.py` | Subprocess isolation with temp files |
| `tmd/imputation_assumptions.py` | Set `REWEIGHT_DEVIATION_PENALTY = 0.0001` |