### PR TITLE
Fix bug described in issue #405

### DIFF
--- a/tmd/datasets/puf.py
+++ b/tmd/datasets/puf.py
@@ -186,7 +186,7 @@ def preprocess_puf(puf: pd.DataFrame) -> pd.DataFrame:
         "non_sch_d_capital_gains": puf.E01100,
         "american_opportunity_credit": puf.E87521,
         "energy_efficient_home_improvement_credit": puf.E07260,
-        "retirement_plan_penalty_tax": puf.E09900,
+        "qualified_retirement_penalty": puf.E09900,
         # "qualified_tuition_expenses": puf.E87530,
         # PE uses the same variable for qualified tuition (general)
         # and qualified tuition (Lifetime Learning Credit). Revisit this.
@@ -263,7 +263,7 @@ FINANCIAL_SUBSET = [
     "other_credits",
     "savers_credit",
     "recapture_of_investment_credit",
-    "retirement_plan_penalty_tax",
+    "qualified_retirement_penalty",
     "unreported_payroll_tax",
     "w2_wages_from_qualified_business",
 ]

--- a/tmd/datasets/taxcalc_dataset.py
+++ b/tmd/datasets/taxcalc_dataset.py
@@ -84,7 +84,7 @@ def create_tc_dataset(pe_dataset: Type, year: int) -> pd.DataFrame:
         "e01100": "non_sch_d_capital_gains",
         "e87521": "american_opportunity_credit",
         "e07260": "energy_efficient_home_improvement_credit",
-        "e09900": "retirement_plan_penalty_tax",
+        "e09900": "qualified_retirement_penalty",
         "p08000": "other_credits",
         "e07240": "savers_credit",
         "e09700": "recapture_of_investment_credit",


### PR DESCRIPTION
Fixes #405 by using correct PolicyEngine-US name for PUF variable `E09900`.

The following test failures will be fixed in a subsequent pull request:
```
E           ValueError: 
E           WEIGHT VARIABLE ACT-vs-EXP DIFFS:
E           WEIGHT_DIFF:sdev,act,exp,atol,rtol= 1142.5726988805463 1140.202438 0.0 0.0005
E tests/test_weights.py:34: ValueError

E           ValueError: 
E           ACT-vs-EXP TAX EXPENDITURE DIFFERENCES:
E           *** actual
E           --- expect
E           ***************
E           *** 1,3 ****
E           ! YR,KIND,EST= 2023 paytax 1385.3
E           ! YR,KIND,EST= 2023 iitax 2236.4
E           ! YR,KIND,EST= 2023 ctc 128.8
E           --- 1,3 ----
E           ! YR,KIND,EST= 2023 paytax 1386.6
E           ! YR,KIND,EST= 2023 iitax 2238.9
E           ! YR,KIND,EST= 2023 ctc 129.1
E           ***************
E           *** 5,7 ****
E           ! YR,KIND,EST= 2023 social_security_partial_taxability 57.3
E           ! YR,KIND,EST= 2023 niit -43.8
E           ! YR,KIND,EST= 2023 cgqd_tax_preference 175.9
E           --- 5,7 ----
E           ! YR,KIND,EST= 2023 social_security_partial_taxability 57.4
E           ! YR,KIND,EST= 2023 niit -43.9
E           ! YR,KIND,EST= 2023 cgqd_tax_preference 176.0
E tests/test_tax_expenditures.py:53: ValueError
```
