### PR TITLE
Address #360: Replace deprecated iprint in scipy L-BFGS-B for area weights with a callback function

### DIFF
--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -573,7 +573,7 @@ def create_area_weights_file(
         iprint = OPTIMIZE_IPRINT
     else:
         iprint = PARAMS.get("iprint", OPTIMIZE_IPRINT)
-    # ... define callback for diagnostic output (replaces deprecated iprint option)
+    # ... define callback for diagnostic output to replace deprecated iprint
     _iter_count = 0
 
     def _diagnostic_callback(intermediate_result):


### PR DESCRIPTION
Addresses #360.

Scipy has deprecated the disp and iprint options of the L-BFGS-B solver used in creating area weights. This PR replaces the use of these options with a callback function, _diagnostic_callback(), that produces similar diagnostic output during diagnostic runs of area weights optimization.