### PR TITLE
Address #419: Fix ambiguous AGI range labels in reweighting output

### DIFF
--- a/tmd/utils/reweight.py
+++ b/tmd/utils/reweight.py
@@ -52,7 +52,7 @@ def fmt(x):
     if x < 1e6:
         return f"{x / 1e3:.0f}k"
     if x < 1e9:
-        return f"{x / 1e6:.0f}m"
+        return f"{x / 1e6:.1f}m"
     return f"{x / 1e9:.1f}bn"
 
 
@@ -141,7 +141,8 @@ def build_loss_matrix(df, targets, time_period):
 
         lob = row["AGI lower bound"]
         hib = row["AGI upper bound"]
-        agi_range_label = f"{fmt(lob)}-{fmt(hib)}"
+        left = "(" if lob == -np.inf else "["
+        agi_range_label = f"{left}{fmt(lob)}, {fmt(hib)})"
         taxable_label = (
             "taxable" if row["Taxable only"] else "all" + " returns"
         )


### PR DESCRIPTION
Addresses #419 raised by @martinholmer.

This PR makes the following changes:

- Use .1f formatting for millions so $1.5M displays as 1.5m instead of rounding to 2m, fixing #419.
- Use interval notation [lower, upper) to clearly show that lower bounds are inclusive and upper bounds are exclusive.

Make data after incorporating this PR produces in the log (with columns aligned properly):

```
worst targets:
0.500% | target=           1707 | achieved=           1716 | count/count/AGI in [10.0m, inf)/all returns/Married Filing Separately
0.500% | target=           6052 | achieved=           6082 | count/count/AGI in [10.0m, inf)/all returns/Single
0.500% | target=           1687 | achieved=           1695 | count/count/AGI in [5.0m, 10.0m)/all returns/Married Filing Separately
0.500% | target=    18785258000 | achieved=    18879184290 | total pension income/total/AGI in [20k, 25k)/all returns/All
0.500% | target=          38208 | achieved=          38017 | partnership and s corp income/count/AGI in [10.0m, inf)/all returns/All
0.500% | target=    15555885000 | achieved=    15633664425 | total pension income/total/AGI in [10k, 15k)/all returns/All
0.500% | target=           2947 | achieved=           2962 | count/count/AGI in [1.5m, 2.0m)/all returns/Married Filing Separately
0.500% | target=         168588 | achieved=         169431 | capital gains gross/count/AGI in (-inf, 0)/all returns/All
0.500% | target=          36520 | achieved=          36703 | count/count/AGI in [10.0m, inf)/all returns/Married Filing Jointly/Surviving Spouse
0.500% | target=     1103007000 | achieved=     1108522035 | partnership and s corp income/total/AGI in [15k, 20k)/all returns/All
```

Before this PR, output was:

```
worst targets:
0.500% | target=           1707 | achieved=           1716 | count/count/AGI in 10m-inf/all returns/Married Filing Separately
0.500% | target=           6052 | achieved=           6082 | count/count/AGI in 10m-inf/all returns/Single
0.500% | target=           1687 | achieved=           1695 | count/count/AGI in 5m-10m/all returns/Married Filing Separately
0.500% | target=    18785258000 | achieved=    18879184290 | total pension income/total/AGI in 20k-25k/all returns/All
0.500% | target=          38208 | achieved=          38017 | partnership and s corp income/count/AGI in 10m-inf/all returns/All
0.500% | target=    15555885000 | achieved=    15633664425 | total pension income/total/AGI in 10k-15k/all returns/All
0.500% | target=           2947 | achieved=           2962 | count/count/AGI in 2m-2m/all returns/Married Filing Separately
0.500% | target=         168588 | achieved=         169431 | capital gains gross/count/AGI in -inf-0/all returns/All
0.500% | target=          36520 | achieved=          36703 | count/count/AGI in 10m-inf/all returns/Married Filing Jointly/Surviving Spouse
0.500% | target=     1103007000 | achieved=     1108522035 | partnership and s corp income/total/AGI in 15k-20k/all returns/All
```


