### PR TITLE
Fix #420, tolerances for tax expenditure tests

### DIFF
--- a/tests/test_tax_expenditures.py
+++ b/tests/test_tax_expenditures.py
@@ -32,7 +32,7 @@ def test_tax_exp_diffs(
         exp = expfile.readlines()
     assert len(act) == len(exp), "number of act and exp rows differ"
     a_tol = 0.1  # handles :.1f rounding of tax expenditures
-    r_tol = 5e-5  # larger than the np.allclose default value of 1e-5
+    r_tol = 1e-5  # np.allclose default value is 1e-5
     diffs = []
     for rowidx, act_row in enumerate(act):
         atok = act_row.split()


### PR DESCRIPTION
@martinholmer, fixes #420, tolerances for tax expenditure tests. Would appreciate your review.

This PR:

- Reverts a_tol for tax expenditure tests to 0.1 from 0.05
- Uses np.allclose() default rtol of 1e-5 but retains the previously used variable r_tol to allow overriding.
- Adjusts comments accordingly

@martin, maybe I should not reinstate the r_tol variable and leave it out? Tests pass with the default 1e-5 so maybe we have no need for it.

