### PR TITLE
Loosen AGI area test tolerance

### DIFF
--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -61,6 +61,7 @@ def test_area_xx(tests_folder):
     # compare actual with expected results
     default_rtol = 0.005
     rtol = {
+        "e00100": 0.008,
         "e00200": 0.008,
     }
     if set(act.keys()) != set(exp.keys()):


### PR DESCRIPTION
Differences across computers seems to be rooted in `jax` usage of GPU if available.

Adopting the new national reweighting algorithm for the area reweighting should fix these cross-computer variations.