### PR TITLE
Change "e00100" to "c00100" to properly loosen AGI area weights test …

### DIFF
--- a/tests/test_area_weights.py
+++ b/tests/test_area_weights.py
@@ -61,7 +61,7 @@ def test_area_xx(tests_folder):
     # compare actual with expected results
     default_rtol = 0.005
     rtol = {
-        "e00100": 0.008,
+        "c00100": 0.008,
         "e00200": 0.008,
     }
     if set(act.keys()) != set(exp.keys()):


### PR DESCRIPTION
…tolerance

PR #435 intended to loosen AGI area weights test tolerance but accidentally used "e00100" as the AGI variable instead of "c00100", which is the actual AGI variable in the test. This one-character change fixes this.