### PR TITLE
Fix `uprate_puf.py` logic to avoid crash when TAXYEAR=2022

### DIFF
--- a/tmd/imputation_assumptions.py
+++ b/tmd/imputation_assumptions.py
@@ -2,7 +2,7 @@
 Central location for data imputation assumptions.
 """
 
-TAXYEAR = 2022  # single source of truth for the target tax year
+TAXYEAR = 2021  # single source of truth for the target tax year
 
 IMPUTATION_RF_RNG_SEED = 1928374  # random number seed used by RandomForest
 


### PR DESCRIPTION
When TAXYEAR was changed from 2021 to 2022, the following crash occurred:
```
python tmd/create_taxcalc_input_variables.py                                    
Creating 2022 PUF+CPS file assuming:                                            
  IMPUTATION_RF_RNG_SEED = 1928374                                              
  IMPUTATION_BETA_RNG_SEED = 37465                                              
  ASSUMED ITMDED_GROW_RATE = 0.020                                              
  ASSUMED W2_WAGES_SCALE = 0.15000                                              
  ASSUMED CPS_WEIGHTS_SCALE = 1.00                                              
Reading raw 2015 PUF data...                                                    
Projecting PUF data from 2015 to 2022...                                        
Pre-processing PUF data...                                                      
Imputing missing PUF demographics...                                            
Computing earnings splits...                                                    
Imputing pension contributions...                                               
Building Tax-Calculator input dataframe for 2022...                             
Creating CPS dataframe for year 2022...                                         
Combining PUF filers and CPS nonfilers...                                       
Adding Tax-Calculator outputs for 2022...                                       
Traceback (most recent call last):                                              
  File "/Users/mrh/TMD/tmd/create_taxcalc_input_variables.py", line 65, in      
<module>                                                                        
    create_variable_file()                                                      
  File "/Users/mrh/TMD/tmd/create_taxcalc_input_variables.py", line 31, in      
create_variable_file                                                            
    vdf = create_tmd_dataframe(TAXYEAR)                                         
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                         
  File "/Users/mrh/TMD/tmd/datasets/tmd.py", line 30, in create_tmd_dataframe   
    combined = add_taxcalc_outputs(combined, taxyear, taxyear)                  
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                  
  File "/Users/mrh/TMD/tmd/utils/taxcalc_utils.py", line 78, in                 
add_taxcalc_outputs                                                             
    rec = tc.Records(                                                           
          ^^^^^^^^^^^                                                           
  File "/Users/mrh/Tax-Calculator/taxcalc/records.py", line 187, in __init__    
    raise ValueError(msg)                                                       
ValueError: expression "e01500 >= e01700" is not true for every record          
```