### PR TITLE
Declare openpyxl as a runtime dependency (closes #480)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ setup(
         "scikit-learn",
         "scipy",
         "xlrd",
+        "openpyxl",
         "black>=26.1.0",
         "pycodestyle>=2.14.0",
         "pylint>=3.3.8",


### PR DESCRIPTION
## Summary

Closes #480.

Adds `"openpyxl"` to `install_requires` in `setup.py` so fresh installs
can read `.xlsx` files without a manual `pip install openpyxl`.

## Why

`pd.read_excel()` on an `.xlsx` file (e.g.
`tmd/areas/targets/prepare/extended_targets.py:139`) requires `openpyxl`.
The existing `"xlrd"` dependency can't handle `.xlsx` because `xlrd`
dropped `.xlsx` support in version 2.0 (December 2020). `openpyxl` is not
pulled in transitively by any other declared dependency, so clean
environments fail `make data` with:

```
ModuleNotFoundError: No module named 'openpyxl'
```

## Verification

- `pip install -e .` — succeeds, openpyxl 3.1.5 installed
- `python -c "import openpyxl"` — succeeds
- `make format` / `make lint` — clean
- Diff is one line added to `setup.py`

## Files changed

| File | Change |
|---|---|
| `setup.py` | add `"openpyxl"` to `install_requires` |
