### PR TITLE
Update OBBBA deduction expected values for taxcalc 6.5.2 (closes #482)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.11,<3.14",
     install_requires=[
-        "taxcalc>=6.5.0",
+        "taxcalc>=6.5.2",
         "clarabel",
         "scikit-learn",
         "scipy",

--- a/tests/test_imputed_variables.py
+++ b/tests/test_imputed_variables.py
@@ -55,9 +55,9 @@ def test_obbba_deduction_tax_benefits(
             # https://taxpolicycenter.org/taxvox/
             #         budget-laws-tax-cuts-overtime-and-
             #         tips-are-popular-few-will-benefit
-            "exp_totben_2022": 24.16,
-            "exp_affpct_2022": 8.77,
-            "exp_affben_2022": 1406,
+            "exp_totben_2022": 23.65,
+            "exp_affpct_2022": 8.56,
+            "exp_affben_2022": 1411,
         },
         "TIP": {  # new OBBBA tip income deduction
             "reform_dict": {"TipIncomeDed_c": {simyear: 0}},
@@ -72,8 +72,8 @@ def test_obbba_deduction_tax_benefits(
             # https://taxpolicycenter.org/taxvox/
             #         budget-laws-tax-cuts-overtime-and-
             #         tips-are-popular-few-will-benefit
-            "exp_totben_2022": 7.21,
-            "exp_affpct_2022": 2.63,
+            "exp_totben_2022": 7.08,
+            "exp_affpct_2022": 2.59,
             "exp_affben_2022": 1397,
         },
         "ALI": {  # new OBBBA auto loan interest deduction
@@ -107,9 +107,9 @@ def test_obbba_deduction_tax_benefits(
             # https://taxpolicycenter.org/model-estimates/T25-0257
             # Note that the $1081 TPC estimate is derived by dividing
             # the all-unit average of $320 by the 0.296 affpct.
-            "exp_totben_2022": 61.77,
-            "exp_affpct_2022": 28.98,
-            "exp_affben_2022": 1088,
+            "exp_totben_2022": 60.86,
+            "exp_affpct_2022": 28.62,
+            "exp_affben_2022": 1086,
         },
     }
     output_variables = [


### PR DESCRIPTION
@martinholmer — this touches national test expectations and the minimum-version pin for Tax-Calculator.
I'd appreciate your review before merge.

## Summary

Closes #482.

Tax-Calculator 6.5.2 (released 2026-04-13,
[PSLmodels/Tax-Calculator#3012](https://github.com/PSLmodels/Tax-Calculator/pull/3012))
correctly makes married-filing-separately tax units ineligible for the
new OBBBA overtime, tip, and senior deductions. This shifts aggregate
2022 OBBBA-deduction benefits by roughly 1%, which is small but exceeds
the 0.01 / 1.0 tolerances hardcoded in
`tests/test_imputed_variables.py::test_obbba_deduction_tax_benefits`.

Under 6.5.1 the test passed; under 6.5.2 it fails on eight values. This
PR updates those eight values to the 6.5.2 output and bumps the
`taxcalc` minimum so that fresh installs pick up the MFS-eligibility
fix automatically and the values cannot silently drift back to 6.5.1.

## Changes

Two files, eight expected-value updates (all in the 2022 rows only —
the dict also contains 2021 rows, but the test reads only
`exp_*_{TAXYEAR}` where `TAXYEAR=2022`, so the 2021 entries are dead
code and are left untouched in this PR):

| Deduction | Statistic | Old (6.5.1) | New (6.5.2) |
|---|---|---|---|
| OTM | `exp_totben_2022` | 24.16 | 23.65 |
| OTM | `exp_affpct_2022` | 8.77 | 8.56 |
| OTM | `exp_affben_2022` | 1406 | 1411 |
| TIP | `exp_totben_2022` | 7.21 | 7.08 |
| TIP | `exp_affpct_2022` | 2.63 | 2.59 |
| ALL | `exp_totben_2022` | 61.77 | 60.86 |
| ALL | `exp_affpct_2022` | 28.98 | 28.62 |
| ALL | `exp_affben_2022` | 1088 | 1086 |

`setup.py`: `taxcalc>=6.5.0` → `taxcalc>=6.5.2`.

## Unchanged values and why

- **TIP `exp_affben_2022` (stays 1397):** average-per-affected-filer
  didn't shift materially when MFS filers were removed.
- **ALI (all three 2022 values unchanged):** the auto-loan-interest
  deduction has no MFS-eligibility clause in OBBBA, so PR
  PSLmodels/Tax-Calculator#3012 does not affect it.
- **All 2021 values in all deductions:** the test is driven by
  `TAXYEAR` from `tmd/imputation_assumptions.py` (currently 2022), so
  `exp_*_2021` entries are not read. They will be cleaned up (or
  updated) in a separate PR if/when anyone cares.

## Verification

Under `taxcalc==6.5.2`:

- `pytest tests/test_imputed_variables.py::test_obbba_deduction_tax_benefits`
  — PASSED (previously FAILED on all eight values above)
- `make data` — 253 passed, 6 skipped, 0 failures
- `make format` / `make lint` — clean

## Relation to other work

- This PR intentionally does **not** regenerate area-weight fingerprint
  files (`tmd/areas/fingerprints/*.json`). A separate PR
  (`fix-issue-477`) updates the area-weight fingerprint mechanism
  itself, and the fingerprint reference JSONs there will be regenerated
  on top of this one once it is merged. That sequencing avoids churning
  the fingerprint JSONs twice.
- The openpyxl dependency fix landed in PR #481 and is already on
  master.

## Files changed

| File | Change |
|---|---|
| `setup.py` | bump `taxcalc>=6.5.0` → `taxcalc>=6.5.2` |
| `tests/test_imputed_variables.py` | update 8 OBBBA-deduction expected values for 2022 |
