### PR TITLE
Ignore area-weighting and reweighting run artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,18 @@ claude/
 # local environment
 venv/
 .venv/
+
+# Area weighting run artifacts (logs and reports produced by weighting runs)
+tmd/areas/weights/**/*.log
+tmd/areas/weights/**/quality_report*.txt
+tmd/areas/weights/**/developer_report.txt
+
+# Reweighting run output (timestamped output directories from reweighting runs)
+tmd/storage/output/reweighting/
+
+# Defensive: build caches that were removed from the pipeline but might
+# reappear if anyone experiments locally with R/Quarto tooling
+**/.quarto/
+**/renv/library/
+**/renv/staging/
+**/renv/local/


### PR DESCRIPTION
Area-weighting and reweighting runs produce large amounts of output (per-area log files, quality and developer reports, and timestamped reweighting output directories) that are reproducible from source and should not be tracked. Adding these patterns keeps the working tree clean for anyone who runs those pipelines locally.

Also defensively ignore Quarto build caches and R renv library/cache directories. The R/Quarto CD pipeline was removed in 1d6abbae, but these patterns prevent stale artifacts from reappearing in source control if anyone experiments with those tools locally.