### PR TITLE
Exclude area-pipeline tests from root `make test`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,12 @@ tmd_files: tmd/storage/output/tmd.csv.gz \
 
 .PHONY=test
 test: tmd_files
-	pytest . -v -n4 --ignore=tests/national_targets_pipeline --ignore=tests/test_fingerprint.py
+	pytest . -v -n4 \
+	    --ignore=tests/national_targets_pipeline \
+	    --ignore=tests/test_fingerprint.py \
+	    --ignore=tests/test_state_weight_results.py \
+	    --ignore=tests/test_cd_crosswalk.py \
+	    --ignore=tests/test_prepare_targets.py
 
 .PHONY=data
 data: install tmd_files test


### PR DESCRIPTION
These three test files belong to the area-weighting pipeline, not to `make data`, and are already invoked by `tmd/areas/Makefile` at the points where their inputs have just been produced:

- tests/test_state_weight_results.py  (state weight files)
- tests/test_cd_crosswalk.py          (CD crosswalk files)
- tests/test_prepare_targets.py       (all tests are area-scoped:
    state-level run from `make -C tmd/areas states` via `-k "not CD"`;
    CD-level run from `make -C tmd/areas cds` via `-k CD`)

Before this change, `make data` either (a) reported large skip noise when area artifacts were absent (~150+ parameterized state-weight tests skipping via `pytest.mark.skipif`), or (b) ran these tests twice when artifacts were present — once from root `make test` and again from the area Makefile.

After this change, `make data` runs only tests relevant to the national TMD it just produced.  `make -C tmd/areas states` and `make -C tmd/areas cds` continue to invoke their tests as before.

This is consistent with the existing `--ignore=tests/national_targets_pipeline` treatment of the other pre-processing pipeline.

Closes #492