### PR TITLE
Add Makefile for national targets pipeline (closes #491)

### DIFF
--- a/tmd/national_targets/Makefile
+++ b/tmd/national_targets/Makefile
@@ -1,0 +1,43 @@
+# National targets pipeline: IRS SOI Excel -> soi.csv
+#
+# This pipeline is pre-processing that runs *before* `make data`.  It
+# produces committed artifacts (data/irs_aggregate_values.csv and
+# tmd/storage/input/soi.csv) that `make data` then consumes.  Most users
+# do not need to run it; re-run it only when adding a new tax year or
+# correcting an extraction error.
+#
+# Usage from repo root:
+#   make -C tmd/national_targets extract    # stage 1: IRS Excel -> per-table CSVs
+#   make -C tmd/national_targets build      # stages 1 + 2: -> irs_aggregate_values.csv
+#   make -C tmd/national_targets soi        # stages 1 + 2 + 3: -> soi.csv
+#   make -C tmd/national_targets all        # all stages + pipeline tests
+#   make -C tmd/national_targets test       # pipeline tests only
+#
+# Stage 1 skips per-table CSVs that already exist.  Pass OVERWRITE=1 to
+# force re-extraction:
+#   make -C tmd/national_targets extract OVERWRITE=1
+
+ROOT := $(realpath $(CURDIR)/../..)
+
+OVERWRITE ?=
+ifeq ($(OVERWRITE),1)
+EXTRACT_FLAGS := --overwrite
+else
+EXTRACT_FLAGS :=
+endif
+
+.PHONY: all extract build soi test
+
+extract:
+	python -m tmd.national_targets.extract_irs_to_csv $(EXTRACT_FLAGS)
+
+build: extract
+	python -m tmd.national_targets.build_targets
+
+soi: build
+	python -m tmd.national_targets.potential_targets_to_soi
+
+test:
+	python -m pytest $(ROOT)/tests/national_targets_pipeline -v
+
+all: soi test

--- a/tmd/national_targets/README.md
+++ b/tmd/national_targets/README.md
@@ -11,18 +11,34 @@ You don't need to run this pipeline. The repo ships a vetted `soi.csv` and
 ## For maintainers
 
 The pipeline is how `soi.csv` gets created and updated. Run it when adding
-a new tax year or correcting an extraction error:
+a new tax year or correcting an extraction error. The stages are wired
+together in `tmd/national_targets/Makefile`:
+
+```bash
+# Run the full pipeline (all three stages) and the pipeline tests:
+make -C tmd/national_targets all
+
+# Individual stages (each depends on the prior stage):
+make -C tmd/national_targets extract   # stage 1: IRS Excel -> per-table CSVs
+make -C tmd/national_targets build     # stages 1 + 2: -> irs_aggregate_values.csv
+make -C tmd/national_targets soi       # stages 1 + 2 + 3: -> soi.csv
+make -C tmd/national_targets test      # pipeline tests only
+
+# Stage 1 skips per-table CSVs that already exist; force re-extraction with:
+make -C tmd/national_targets extract OVERWRITE=1
+
+# Verify the full build still passes:
+make clean && make data
+```
+
+The manual command sequence below is equivalent to `make -C tmd/national_targets all`
+and is retained for reference:
 
 ```bash
 python -m tmd.national_targets.extract_irs_to_csv --overwrite
 python -m tmd.national_targets.build_targets
 python -m tmd.national_targets.potential_targets_to_soi
-
-# Pipeline-specific tests (not part of make data)
 python -m pytest tests/national_targets_pipeline -v
-
-# Verify the full build still passes
-make clean && make data
 ```
 
 See [docs/adding_a_new_year.md](docs/adding_a_new_year.md) for step-by-step


### PR DESCRIPTION
## Summary

  Adds `tmd/national_targets/Makefile` that wires the three national
  targets pre-processing stages and their tests into a single interface,
  parallel to `tmd/areas/Makefile`. Maintainers no longer need to
  re-derive the command sequence from the README when adding a new tax
  year or correcting an extraction error, and pipeline tests now run
  automatically after the outputs are produced.

  ## Targets

  - `make -C tmd/national_targets all` — all stages + pipeline tests
  
  - `make -C tmd/national_targets extract` — stage 1: IRS Excel → per-table CSVs
  - `make -C tmd/national_targets build` — stages 1 + 2 → `irs_aggregate_values.csv`
  - `make -C tmd/national_targets soi` — stages 1 + 2 + 3 → `soi.csv`
  - `make -C tmd/national_targets test` — pipeline tests only

  Stage 1 skips per-table CSVs that already exist (matching the current CLI default). Pass `OVERWRITE=1` 
  to any of the commands that include stage 1 to force re-extraction. Examples:
  
  `make -C tmd/national_targets extract OVERWRITE=1`
  `make -C tmd/national_targets all OVERWRITE=1`

  No behavior changes to the underlying scripts; this is purely an
  orchestration / ergonomics improvement.

  ## Test plan

  - [x] `make -C tmd/national_targets test` — 79 passed
  - [x] `make -C tmd/national_targets -n all` — dry-run shows the expected command sequence
  - [x] `make format && make lint` — clean