### PR TITLE
Capture pipeline warnings and surface test-run warnings (addresses #430, #495)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,9 @@ tmd/areas/weights/**/developer_report.txt
 # Reweighting run output (timestamped output directories from reweighting runs)
 tmd/storage/output/reweighting/
 
+# Pipeline warning log produced by `make data` (see `make warnings`)
+tmd/storage/output/make_data.log
+
 # Defensive: build caches that were removed from the pipeline but might
 # reappear if anyone experiments locally with R/Quarto tooling
 **/.quarto/

--- a/.gitignore
+++ b/.gitignore
@@ -33,8 +33,8 @@ tmd/areas/weights/**/developer_report.txt
 # Reweighting run output (timestamped output directories from reweighting runs)
 tmd/storage/output/reweighting/
 
-# Pipeline warning log produced by `make data` (see `make warnings`)
-tmd/storage/output/make_data.log
+# Per-stage pipeline logs produced by `make data` (see `make warnings`)
+tmd/storage/output/make_data_*.log
 
 # Defensive: build caches that were removed from the pipeline but might
 # reappear if anyone experiments locally with R/Quarto tooling

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ test: tmd_files
 	    --ignore=tests/test_prepare_targets.py
 
 .PHONY=data
-data: install tmd_files test
+data: install tmd_files test warnings
 
 .PHONY=warnings
 warnings:
@@ -68,7 +68,7 @@ warnings:
 	if [ -z "$$logs" ]; then \
 	    echo "No tmd/storage/output/make_data_*.log files found; run 'make data' first."; \
 	else \
-	    hits=$$(grep -niHE 'warning|deprecat' $$logs || true); \
+	    hits=$$(grep -nHE '[Ww]arning|[Dd]eprecat|Traceback|\bERROR\b|Error:' $$logs || true); \
 	    if [ -z "$$hits" ]; then \
 	        echo "No warnings found in pipeline logs:"; \
 	        for f in $$logs; do echo "  $$f"; done; \

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,9 @@
+# Force bash with pipefail so that a failure in the first stage of a
+# pipeline (e.g., `python ... 2>&1 | tee log`) propagates as a recipe
+# failure instead of being masked by tee's exit status.
+SHELL := /bin/bash
+.SHELLFLAGS := -eo pipefail -c
+
 .PHONY=install
 install:
 	pip install -e .
@@ -7,9 +13,15 @@ clean:
 	rm -f tmd/storage/output/tmd*
 	rm -f tmd/storage/output/cached*
 	rm -f tmd/storage/output/preimpute_tmd.csv.gz
+	rm -f tmd/storage/output/make_data.log
 
+# Main imputation/calibration pipeline.  Output is tee'd to
+# make_data.log so that warnings emitted during the run (pandas,
+# numpy, taxcalc, etc.) are captured and can be reviewed afterward via
+# `make warnings`.  On-screen output during the build is unchanged.
 tmd/storage/output/tmd.csv.gz:
-	python tmd/create_taxcalc_input_variables.py
+	python tmd/create_taxcalc_input_variables.py 2>&1 \
+	    | tee tmd/storage/output/make_data.log
 
 tmd/storage/output/tmd_weights.csv.gz:
 	python tmd/create_taxcalc_sampling_weights.py
@@ -41,6 +53,21 @@ test: tmd_files
 
 .PHONY=data
 data: install tmd_files test
+
+.PHONY=warnings
+warnings:
+	@log=tmd/storage/output/make_data.log; \
+	if [ ! -f "$$log" ]; then \
+	    echo "No $$log found; run 'make data' first."; \
+	else \
+	    hits=$$(grep -niE 'warning|deprecat' "$$log" || true); \
+	    if [ -z "$$hits" ]; then \
+	        echo "No warnings found in $$log."; \
+	    else \
+	        echo "Warnings in $$log:"; \
+	        echo "$$hits"; \
+	    fi; \
+	fi
 
 .PHONY=format
 format:

--- a/Makefile
+++ b/Makefile
@@ -13,27 +13,35 @@ clean:
 	rm -f tmd/storage/output/tmd*
 	rm -f tmd/storage/output/cached*
 	rm -f tmd/storage/output/preimpute_tmd.csv.gz
-	rm -f tmd/storage/output/make_data.log
+	rm -f tmd/storage/output/make_data_*.log
 
-# Main imputation/calibration pipeline.  Output is tee'd to
-# make_data.log so that warnings emitted during the run (pandas,
-# numpy, taxcalc, etc.) are captured and can be reviewed afterward via
-# `make warnings`.  On-screen output during the build is unchanged.
+# Each of the five build stages below tees its stdout+stderr to a
+# per-stage log file in tmd/storage/output/.  On-screen output during
+# `make data` is unchanged; the log files are a byproduct so that any
+# warnings emitted during the run (pandas, numpy, taxcalc, scipy,
+# etc.) can be reviewed afterward via `make warnings`.  Per-stage
+# (rather than shared) log files avoid interleaving when the recipes
+# are run with `make -j`.
+
 tmd/storage/output/tmd.csv.gz:
 	python tmd/create_taxcalc_input_variables.py 2>&1 \
-	    | tee tmd/storage/output/make_data.log
+	    | tee tmd/storage/output/make_data_tmd.log
 
 tmd/storage/output/tmd_weights.csv.gz:
-	python tmd/create_taxcalc_sampling_weights.py
+	python tmd/create_taxcalc_sampling_weights.py 2>&1 \
+	    | tee tmd/storage/output/make_data_weights.log
 
 tmd/storage/output/tmd_growfactors.csv:
-	python tmd/create_taxcalc_growth_factors.py
+	python tmd/create_taxcalc_growth_factors.py 2>&1 \
+	    | tee tmd/storage/output/make_data_growfactors.log
 
 tmd/storage/output/cached_files:
-	python tmd/create_taxcalc_cached_files.py
+	python tmd/create_taxcalc_cached_files.py 2>&1 \
+	    | tee tmd/storage/output/make_data_cached.log
 
 tmd/storage/output/preimpute_tmd.csv.gz:
-	python tmd/create_taxcalc_imputed_variables.py
+	python tmd/create_taxcalc_imputed_variables.py 2>&1 \
+	    | tee tmd/storage/output/make_data_preimpute.log
 
 .PHONY=tmd_files
 tmd_files: tmd/storage/output/tmd.csv.gz \
@@ -56,15 +64,16 @@ data: install tmd_files test
 
 .PHONY=warnings
 warnings:
-	@log=tmd/storage/output/make_data.log; \
-	if [ ! -f "$$log" ]; then \
-	    echo "No $$log found; run 'make data' first."; \
+	@logs=$$(ls tmd/storage/output/make_data_*.log 2>/dev/null || true); \
+	if [ -z "$$logs" ]; then \
+	    echo "No tmd/storage/output/make_data_*.log files found; run 'make data' first."; \
 	else \
-	    hits=$$(grep -niE 'warning|deprecat' "$$log" || true); \
+	    hits=$$(grep -niHE 'warning|deprecat' $$logs || true); \
 	    if [ -z "$$hits" ]; then \
-	        echo "No warnings found in $$log."; \
+	        echo "No warnings found in pipeline logs:"; \
+	        for f in $$logs; do echo "  $$f"; done; \
 	    else \
-	        echo "Warnings in $$log:"; \
+	        echo "Warnings in pipeline logs:"; \
 	        echo "$$hits"; \
 	    fi; \
 	fi

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,11 @@
 [pytest]
 testpaths =
     tmd
+# Surface warnings in pytest's end-of-run summary.  Pipeline-run
+# warnings (those emitted during `make data`) are captured separately
+# to tmd/storage/output/make_data.log; see `make warnings`.
+filterwarnings =
+    default
 markers =
     pop
     taxexp


### PR DESCRIPTION
Addresses #430 and #495 by replacing the coverage role of the proposed-to-be-retired
`test_create_file` (PR #496) with a cheaper mechanism that
does not re-run the full TMD construction pipeline inside pytest.

See issue #495 for motivation and alternatives considered.

## Scope: all five build stages in `tmd_files`

The root `Makefile` chains five separate scripts to produce the files
`make test` depends on. All five now tee stdout+stderr to their own
per-stage log file:

| # | Build target | Script | What it does | Log file |
|---|---|---|---|---|
| 1 | `tmd/storage/output/tmd.csv.gz` | `create_taxcalc_input_variables.py` | Main imputation / calibration | `make_data_tmd.log` |
| 2 | `tmd/storage/output/tmd_weights.csv.gz` | `create_taxcalc_sampling_weights.py` | Weight solving | `make_data_weights.log` |
| 3 | `tmd/storage/output/tmd_growfactors.csv` | `create_taxcalc_growth_factors.py` | Growth factors | `make_data_growfactors.log` |
| 4 | `tmd/storage/output/cached_files` | `create_taxcalc_cached_files.py` | Cached intermediates | `make_data_cached.log` |
| 5 | `tmd/storage/output/preimpute_tmd.csv.gz` | `create_taxcalc_imputed_variables.py` | Pre-imputation snapshot | `make_data_preimpute.log` |

The retired `test_create_file` only exercised stage 1. Expanding the
capture to all five stages is a broader net than the original test
provided, catching warnings that could emerge anywhere in the pipeline
(e.g., scipy `RuntimeWarning` during weight optimization, pandas
`FutureWarning` in growth-factor processing).

### Why per-stage logs instead of one shared log

Make can run the five stages in parallel (`make -j`). Two processes
writing to the same file via `| tee -a` interleave their output line
by line, which can split individual warning messages across stages
and produce a log that's hard to read and fragile to grep. Per-stage
log files side-step this entirely: each process owns its own file, no
interleaving possible, and `make warnings` already prefixes each hit
with the filename so attributing a warning to a stage is easy.

The root `Makefile` is typically run serially today (parallelism lives
in `tmd/areas/Makefile`), so this is a precaution rather than a
current need — but the cost is low and it removes a future foot-gun.

## Changes

1. **Tee each of the five pipeline recipes** in the root `Makefile` to
   its own `make_data_<stage>.log` under `tmd/storage/output/`.
   On-screen output during `make data` is unchanged; the log files
   are byproducts.
2. **New `make warnings` target** that scans all per-stage logs and
   prints any lines matching `warning|deprecat` (prefixed with the
   file they came from), or reports the logs are clean. Surfacing
   tool, not a pass/fail gate — intentional, to avoid the
   maintenance burden and decision-rules burden (deciding which
   warnings should cause failure) of a pass/fail test.
3. **`filterwarnings = default` in `pytest.ini`** so warnings emitted
   during the test phase (notably Tax-Calculator `sim.calc_all()`
   calls reached by existing fixtures) appear in pytest's end-of-run
   summary. Separate channel from (1) and (2) — covers test-time
   warnings, not pipeline-run warnings.
4. **`SHELL := /bin/bash` + `.SHELLFLAGS := -eo pipefail -c`** at the
   top of the `Makefile` so a failure in the first stage of a
   pipeline (e.g., a python script feeding `tee`) propagates as a
   recipe failure instead of being masked by `tee`'s exit status.
5. **`.gitignore`** excludes `tmd/storage/output/make_data_*.log`.
6. **`make clean`** removes the log files.

## Test plan

- [x] `make format` — clean
- [x] `make lint` — clean
- [x] `make warnings` with no logs → "No ... log files found; run 'make data' first."
- [x] `make warnings` with fabricated logs containing warnings → lists them, prefixed by filename
- [x] `make warnings` with fabricated clean logs → "No warnings found in pipeline logs: …"
- [x] Pipefail verified: failing command in a `tee` pipeline now fails the recipe (silently ignored before this PR).
- [x] `pytest tests/test_misc.py` runs cleanly with new `pytest.ini`.

Requesting @martinholmer review.
