### PR TITLE
Refactor `soi_state_data.py` code to eliminate pandas PerformanceWarning

### DIFF
--- a/tmd/areas/prepare/soi_cd_data.py
+++ b/tmd/areas/prepare/soi_cd_data.py
@@ -108,7 +108,8 @@ def read_soi_cd_csv(
                 "cong_district": "cd117_district",
             }
         )
-        df["year"] = yr
+        year_col = pd.Series(yr, index=df.index, name="year")
+        df = pd.concat([df, year_col], axis=1)
 
         # Drop US-total row
         df = df[df["stabbr"] != "US"].copy()

--- a/tmd/areas/prepare/soi_state_data.py
+++ b/tmd/areas/prepare/soi_state_data.py
@@ -96,7 +96,8 @@ def read_soi_state_csvs(
         df = pd.read_csv(fpath, thousands=",")
         df.columns = [c.lower() for c in df.columns]
         df = df.rename(columns={"state": "stabbr", "agi_stub": "agistub"})
-        df["year"] = yr
+        year_col = pd.Series(yr, index=df.index, name="year")
+        df = pd.concat([df, year_col], axis=1)
         frames.append(df)
     return pd.concat(frames, ignore_index=True)
 


### PR DESCRIPTION
Final code revision required to fix completely issue #489.

After the changes in this PR, none of the following commands generate a PerformanceWarning:
```
TMD> make data
areas> make states
areas> CONGRESS=119 make cd-targets 
```

