### PR TITLE
Restore real-time terminal output during pipeline stages (fixes regression introduced in PR 497)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,25 +22,32 @@ clean:
 # etc.) can be reviewed afterward via `make warnings`.  Per-stage
 # (rather than shared) log files avoid interleaving when the recipes
 # are run with `make -j`.
+#
+# `python -u` forces unbuffered stdout/stderr.  Without it, piping
+# python through `tee` causes python to switch from line buffering
+# (its default when stdout is a terminal) to block buffering (its
+# default when stdout is a pipe), which makes long-running stages
+# appear silent on the terminal until the buffer flushes.  The `-u`
+# flag preserves the pre-tee behavior of seeing progress in real time.
 
 tmd/storage/output/tmd.csv.gz:
-	python tmd/create_taxcalc_input_variables.py 2>&1 \
+	python -u tmd/create_taxcalc_input_variables.py 2>&1 \
 	    | tee tmd/storage/output/make_data_tmd.log
 
 tmd/storage/output/tmd_weights.csv.gz:
-	python tmd/create_taxcalc_sampling_weights.py 2>&1 \
+	python -u tmd/create_taxcalc_sampling_weights.py 2>&1 \
 	    | tee tmd/storage/output/make_data_weights.log
 
 tmd/storage/output/tmd_growfactors.csv:
-	python tmd/create_taxcalc_growth_factors.py 2>&1 \
+	python -u tmd/create_taxcalc_growth_factors.py 2>&1 \
 	    | tee tmd/storage/output/make_data_growfactors.log
 
 tmd/storage/output/cached_files:
-	python tmd/create_taxcalc_cached_files.py 2>&1 \
+	python -u tmd/create_taxcalc_cached_files.py 2>&1 \
 	    | tee tmd/storage/output/make_data_cached.log
 
 tmd/storage/output/preimpute_tmd.csv.gz:
-	python tmd/create_taxcalc_imputed_variables.py 2>&1 \
+	python -u tmd/create_taxcalc_imputed_variables.py 2>&1 \
 	    | tee tmd/storage/output/make_data_preimpute.log
 
 .PHONY=tmd_files


### PR DESCRIPTION
Fixes a regression introduced by #497 that made `make data` appear to hang silently during each of the five pipeline stages.

#497 wrapped each pipeline stage in `python ... 2>&1 | tee <stage>.log` so that warnings could be captured to per-stage log files and reviewed via `make warnings`. That part still works — the log files are written correctly. But a side effect of the `| tee` was that Python's stdout is now a pipe rather than a terminal, and Python's I/O behavior changes based on that:

- When Python's stdout is a terminal, it uses **line buffering**: every newline triggers an immediate write, so progress messages appear on screen as they are printed.
- When Python's stdout is a pipe, it switches to **block buffering**: the interpreter accumulates roughly 4–8 KB of output before writing anything, and for many of these long-running stages the buffer never fills until process exit.

So after #497, the bytes still reached both the terminal and the log file (`tee` was passing them through correctly), but they all arrived in a burst at the end of each stage instead of in real time. From the user's perspective `make data` looked silent for long stretches.

## Fix

Add `-u` to each `python` invocation in the five pipeline recipes in the root `Makefile`. The `-u` flag forces Python to use unbuffered stdout/stderr regardless of whether stdout is a terminal or a pipe, which restores the pre-#497 behavior of seeing progress messages in real time.