### PR TITLE
Require taxcalc 6.5.3 or higher

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,7 @@ test: tmd_files
 	    --ignore=tests/test_prepare_targets.py
 
 .PHONY=data
-data: install tmd_files test warnings
+data: install clean format lint tmd_files test warnings
 
 .PHONY=warnings
 warnings:

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ To generate the TMD files from the PUF files, do this:
 1. Copy the two 2015 PUF files to the `tmd/storage/input` folder
 2. Install the SIPP files described in `tmd/storage/input/SIPP24/README.md`
 3. Install the CEX files described in `tmd/storage/input/CEX23/README.md`
-4. Run `make clean` in the repository's top-level folder
-5. Run `make data` in the repository's top-level folder
+4. Run `make data` in the repository's top-level folder
 
 The `make data` command creates and tests the three national
 `tmd*csv*` data files, which are located in the `tmd/storage/output`

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.11,<3.14",
     install_requires=[
-        "taxcalc>=6.5.2",
+        "taxcalc>=6.5.3",
         "numpy",
         "pandas>=3.0.2",
         "clarabel",

--- a/tests/test_imputed_variables.py
+++ b/tests/test_imputed_variables.py
@@ -107,9 +107,9 @@ def test_obbba_deduction_tax_benefits(
             # https://taxpolicycenter.org/model-estimates/T25-0257
             # Note that the $1081 TPC estimate is derived by dividing
             # the all-unit average of $320 by the 0.296 affpct.
-            "exp_totben_2022": 60.86,
-            "exp_affpct_2022": 28.62,
-            "exp_affben_2022": 1086,
+            "exp_totben_2022": 58.89,
+            "exp_affpct_2022": 28.24,
+            "exp_affben_2022": 1065,
         },
     }
     output_variables = [


### PR DESCRIPTION
No changes in generated TMD data; just one test change wrt OBBBA senior deduction.
Will be merged after taxcalc 6.5.3 package is available for download.