### PR TITLE
Improve area targeting documentation for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ TMD files with Tax-Calculator.
 
 ## Sub-national area weights
 
-The repository also produces **per-area weight files** that adapt
-the national TMD microdata to a specific state or Congressional
-district.  The records do not change; only the weights do, so that
-weighted sums match state-level (or CD-level) totals from IRS
-Statistics of Income (SOI) and other published sources.
+The repository also produces **per-area weight files** that adapt the national
+TMD microdata to a specific state or Congressional district.  The records do not
+change; only the weights do, so that weighted sums and targeted distributional
+values match state-level (or CD-level) totals from IRS Statistics of Income
+(SOI) and other published sources.
 
 See [`tmd/areas/README.md`](tmd/areas/README.md) for how to build
 the weights, what files you get, and how to use them — with or

--- a/README.md
+++ b/README.md
@@ -47,3 +47,15 @@ documentation](https://taxcalc.pslmodels.org/usage/data.html#irs-public-use-data
 on how to use these three files with Tax-Calculator.  Also, you can
 look at the tests in this repository to see Python code that uses the
 TMD files with Tax-Calculator.
+
+## Sub-national area weights
+
+The repository also produces **per-area weight files** that adapt
+the national TMD microdata to a specific state or Congressional
+district.  The records do not change; only the weights do, so that
+weighted sums match state-level (or CD-level) totals from IRS
+Statistics of Income (SOI) and other published sources.
+
+See [`tmd/areas/README.md`](tmd/areas/README.md) for how to build
+the weights, what files you get, and how to use them — with or
+without Tax-Calculator.

--- a/tmd/README.md
+++ b/tmd/README.md
@@ -6,4 +6,4 @@ This package has five submodules:
 * examination: contains code for examining the quality of the national datasets.
 * storage: contains national input and output data created by this package.
 * utils: contains utility functions that aren't specific to one dataset.
-* areas: contains code for generating sub-national area weights and examining their quality.
+* [areas](areas/README.md): contains code for generating sub-national area weights and examining their quality.

--- a/tmd/areas/README.md
+++ b/tmd/areas/README.md
@@ -1,32 +1,20 @@
 # Sub-national area weights
 
-This folder contains everything needed to produce **per-area weight
-files** that adapt the national TMD microdata to a specific state or
-Congressional district.
+This folder contains everything needed to produce **per-area weight files** that adapt the national TMD microdata to a specific state or Congressional district.
 
-The national TMD file has one record per tax-filing unit and one
-weight per record (`s006`).  Those weights make weighted sums match
-national totals.  An area weight file replaces `s006` with a set of
-**area-specific** weights, so weighted sums of the same records match
-state-level (or CD-level) totals from IRS Statistics of Income (SOI).
-The records do not change; only the weights do.
+The national TMD file has one record per tax-filing unit and one weight per record (`s006`). Those weights make weighted sums match targeted national totals. An area weight file replaces `s006` with a set of **area-specific** weights, so weighted sums and targeted distributional values of the same records match state-level (or CD-level) totals from IRS Statistics of Income (SOI). The records do not change; only the weights do.
 
-This README is the user-facing entry point.  For deeper background
-on how the targets are constructed and how the optimizer works, see:
+This README is the user-facing entry point. For deeper background on how the targets are constructed and how the optimizer works, see:
 
-- [AREA_WEIGHTING_GUIDE.md](AREA_WEIGHTING_GUIDE.md) — concepts,
-  target architecture, recipe contents, file locations.
-- [AREA_WEIGHTING_LESSONS.md](AREA_WEIGHTING_LESSONS.md) — practical
-  lessons from production runs (parameter choices, weight
-  exhaustion, bystander effects, SALT targeting).
-- [weights/README.md](weights/README.md) — weight-file format and
-  how to use the files with Tax-Calculator.
+- [AREA_WEIGHTING_GUIDE.md](AREA_WEIGHTING_GUIDE.md) — concepts, target architecture, recipe contents, file locations.
+- [AREA_WEIGHTING_LESSONS.md](AREA_WEIGHTING_LESSONS.md) — practical lessons from production runs (parameter choices, weight exhaustion, bystander effects, SALT targeting).
+- [weights/README.md](weights/README.md) — weight-file format and how to use the files with Tax-Calculator.
 - [targets/README.md](targets/README.md) — targets-file format.
 
 ## What you can do here
 
 | Task | Section |
-|---|---|
+|------------------------------------|------------------------------------|
 | Build all 51 state weight files | [Quickstart](#quickstart) |
 | Build all 436 CD weight files (118th or 119th Congress) | [Quickstart](#quickstart) |
 | Re-solve weights for one area or a few | [Single area](#building-weights-for-a-single-area) |
@@ -37,16 +25,13 @@ on how the targets are constructed and how the optimizer works, see:
 
 ## Prerequisites
 
-The national TMD files must already exist in `tmd/storage/output/`.
-If they do not, run `make data` from the repository root first.
+The national TMD files must already exist in `tmd/storage/output/`. If they do not, run `make data` from the repository root first.
 
-## Quickstart
+## Quickstart {#quickstart}
 
-The full pipeline for each scope (shares → targets → weights → tests
-and quality report) is wired into `tmd/areas/Makefile`.  From the
-repository root:
+The full pipeline for each scope (shares → targets → weights → tests and quality report) is wired into `tmd/areas/Makefile`. From the repository root (adjust WORKERS as appropriate for your machine):
 
-```bash
+``` bash
 # All 51 states (50 states + DC), 8 parallel workers:
 make -C tmd/areas states WORKERS=8
 
@@ -58,45 +43,25 @@ make -C tmd/areas cds-118 WORKERS=16
 make -C tmd/areas cds-119 WORKERS=16
 ```
 
-State runs take a few minutes; CD runs take longer because there are
-more areas.  These Make targets always rebuild every stage (shares,
-targets, weights, tests, quality report) — once you know what
-changed upstream, the single-stage commands in
-[When to rerun which stage](#when-to-rerun-which-stage) are
-faster.
+State runs take a few minutes; CD runs take longer because there are more areas. These Make targets always rebuild every stage (shares, targets, weights, tests, quality report) — once you know what changed upstream, the single-stage commands in [When to rerun which stage](#when-to-rerun-which-stage) are faster.
 
-For Congressional districts the choice of Congressional session is required —
-there is no default.  118th and 119th both have 436 districts (435
-voting + DC); only the geographies differ.
+For Congressional districts the choice of Congressional session is required — there is no default. 118th and 119th both have 436 districts (435 voting + DC); only the geographies differ.
 
 ## Outputs
 
 After a successful run you get three kinds of files:
 
-- **Targets** — one CSV per area in `tmd/areas/targets/states/` or
-  `tmd/areas/targets/cds_118/` (or `cds_119/`).  Each row is one
-  weighted sum the area is asked to match.  See
-  [targets/README.md](targets/README.md) for the file format.
-- **Weights** — one gzipped CSV per area in `tmd/areas/weights/...`,
-  named `<area>_tmd_weights.csv.gz`.  One row per TMD record, with
-  thirteen weight columns (`WT2022` through `WT2034`, one per year).
-  See [weights/README.md](weights/README.md) for how to use these
-  with Tax-Calculator.
-- **Solver log** — `<area>.log` next to each weight file, with the
-  population share used, target accuracy statistics, the weight
-  multiplier distribution, and per-target slack.
+- **Targets** — one CSV per area in `tmd/areas/targets/states/` or `tmd/areas/targets/cds_118/` (or `cds_119/`). Each row is one weighted sum the area is asked to match. See [targets/README.md](targets/README.md) for the file format.
+- **Weights** — one gzipped CSV per area in `tmd/areas/weights/...`, named `<area>_tmd_weights.csv.gz`. One row per TMD record, with thirteen weight columns (`WT2022` through `WT2034`, one per year). See [weights/README.md](weights/README.md) for how to use these with Tax-Calculator.
+- **Solver log** — `<area>.log` next to each weight file, with the population share used, target accuracy statistics, the weight multiplier distribution, and per-target slack.
 
-## Building weights for a single area
+## Building weights for a single area {#building-weights-for-a-single-area}
 
-You can re-solve any single state or single CD by passing its area
-code to `--scope`.  This is much faster than running the full batch
-and is the right approach when you are tuning solver parameters,
-testing a recipe change, or investigating one area.
+You can re-solve any single state or single CD by passing its area code to `--scope`. This is much faster than running the full batch and is the right approach when you are tuning solver parameters, testing a recipe change, or investigating one area.
 
-State codes are two-letter postal codes (lowercase or uppercase).
-CD codes are state code + two-digit district, e.g., `MN01`, `NY12`.
+State codes are two-letter postal codes (lowercase or uppercase). CD codes are state code + two-digit district, e.g., `MN01`, `NY12`.
 
-```bash
+``` bash
 # Re-solve one state, using existing target and shares files:
 python -m tmd.areas.solve_weights --scope CA
 
@@ -107,50 +72,40 @@ python -m tmd.areas.solve_weights --scope CA,NY,TX --workers 4
 python -m tmd.areas.solve_weights --scope MN01 --congress 118
 ```
 
-These commands assume the area's targets file already exists.  If
-it does not, or if any of the inputs that feed into targets has
-changed, see the next section.
+These commands assume the area's targets file already exists. If it does not, or if any of the inputs that feed into targets has changed, see the next section.
 
-## When to rerun which stage
+## When to rerun which stage {#when-to-rerun-which-stage}
 
 A target is constructed as
 
-    target = TMD national sum × geographic share
+```
+target = TMD national sum × geographic share
+```
 
-so a target file goes stale only when one of those inputs changes.
-This table shows what to rerun when something upstream changes:
+so a target file goes stale only when one of those inputs changes. This table shows what to rerun when something upstream changes:
 
 | What changed | Rerun |
-|---|---|
+|------------------------------------|------------------------------------|
 | Solver parameter only (e.g., `multiplier_max`) | `solve_weights` |
 | Recipe / target spec | `prepare_targets`, then `solve_weights` |
 | TMD national file (`make data` was rerun) | `prepare_targets`, then `solve_weights` |
 | New SOI vintage, or Census data update | `prepare_shares`, then `prepare_targets`, then `solve_weights` |
 | Adding a previously-unsolved area | `solve_weights --scope <area>` |
 
-`make -C tmd/areas states` (and `cds-118` / `cds-119`) always reruns
-every stage; that is the simplest and safest entry point if you are
-unsure what is stale.  The single-stage commands are the right tool
-once you know which input changed.
+`make -C tmd/areas states` (and `cds-118` / `cds-119`) always reruns every stage; that is the simplest and safest entry point if you are unsure what is stale. The single-stage commands are the right tool once you know which input changed.
 
 ## Quality reports
 
 Two reports help you judge whether the area weights are good:
 
-- The **multi-area quality report** is a roll-up across many areas
-  (all states, all CDs, or a list).  Use it to see overall hit
-  rates, weight distortion, and bystander effects.
-- The **individual-area detail report** is the same report restricted
-  to a single area or a small list, with full per-target detail.
-  Use it to dig into one place that looked unusual in the roll-up.
+- The **multi-area quality report** is a roll-up across many areas (all states, all CDs, or a list). Use it to see overall hit rates, weight distortion, and bystander effects (effects of reweighting on selected non-targeted variables).
+- The **individual-area detail report** is the same report restricted to a single area or a small list, with full per-target detail. Use it to dig into one place that looked unusual in the roll-up.
 
-Both modes are produced by the same command,
-`tmd.areas.quality_report`.  The only difference is what you pass
-to `--scope`.
+Both modes are produced by the same command, `tmd.areas.quality_report`. The only difference is what you pass to `--scope`.
 
-### Multi-area quality report
+### Multi-area quality report {#multi-area-quality-report}
 
-```bash
+``` bash
 # All 51 states:
 python -m tmd.areas.quality_report --scope states
 
@@ -164,42 +119,24 @@ python -m tmd.areas.quality_report --scope cds --congress 119 --output
 
 The roll-up covers:
 
-- **Solve status** — how many areas solved cleanly, how many used
-  per-area overrides, how many failed.
-- **Target accuracy** — per-area hit rates and the largest
-  violations.
-- **Weight distortion** — distribution of weight multipliers
-  (how far weights moved from population-proportional).
-- **Weight exhaustion** — which records get oversubscribed across
-  areas.
-- **Cross-area aggregation** — sum-of-areas vs national for key
-  variables, so you can confirm the area weights are consistent
-  with the national totals.
-- **Bystander analysis** — variables that are not targeted but are
-  still pushed around by the optimizer; >2% distortion is flagged.
+- **Solve status** — how many areas solved cleanly, how many used per-area overrides, how many failed.
+- **Target accuracy** — per-area hit rates and the largest violations.
+- **Weight distortion** — distribution of weight multipliers (how far weights moved from population-proportional).
+- **Weight exhaustion** — which records get oversubscribed across areas.
+- **Cross-area aggregation** — sum-of-areas vs national for key variables, so you can confirm the area weights are consistent with the national totals.
+- **Bystander analysis** — variables that are not targeted but are still pushed around by the optimizer; \>2% distortion is flagged.
 
-A multi-area run also writes one machine-readable CSV alongside the
-weight files:
+A multi-area run also writes one machine-readable CSV alongside the weight files:
 
-- **`quality_report_per_area.csv`** — one row per area, with columns
-  for record counts, weighted returns, weighted AGI, average AGI,
-  the multiplier distribution (median, p95, max, share zero), and
-  two summary diagnostics (`unusualness` and effective sample size
-  `ess`).  This file covers **every** area in the run, so it is the
-  right input when you want to sort, filter, or plot results across
-  the full set.
+- **`quality_report_per_area.csv`** — one row per area, with columns for record counts, weighted returns, weighted AGI, average AGI, the multiplier distribution (median, p95, max, share zero), and two summary diagnostics (`unusualness` and effective sample size `ess`). This file covers **every** area in the run, so it is the right input when you want to sort, filter, or plot results across the full set.
 
-For CDs, the per-area table inside the text report shows only the
-20 most-distorted areas to keep the report a manageable length; the
-CSV does not truncate.
+For CDs, the per-area table inside the text report shows only the 20 most-distorted areas to keep the report a manageable length; the CSV includes all areas.
 
-### Individual-area detail report
+### Individual-area detail report {#individual-area-detail-report}
 
-To zoom in on one area, pass its code (or a short list) to
-`--scope`.  The report layout is the same; the per-area sections
-just have one entry.
+To zoom in on one area, pass its code (or a short list) to `--scope`. The report layout is the same; the per-area sections just have one entry.
 
-```bash
+``` bash
 # A single state:
 python -m tmd.areas.quality_report --scope CA
 
@@ -214,13 +151,11 @@ python -m tmd.areas.quality_report --scope MN01,MN02 --congress 118
 python -m tmd.areas.quality_report --scope CA -o ca_report.txt
 ```
 
-### Single-area diagnostics
+### Single-area diagnostics {#single-area-diagnostics}
 
-For a deeper look at a single area, the developer-tools module
-provides two purpose-built diagnostics that are also useful to
-analysts:
+For a deeper look at a single area, the developer-tools module provides two purpose-built diagnostics that are also useful to analysts:
 
-```bash
+``` bash
 # Why is this area hard to fit?  Per-target gap from a
 # population-proportionate share, sorted from largest to smallest:
 python -m tmd.areas.developer_tools --difficulty AL01 --congress 118
@@ -230,10 +165,7 @@ python -m tmd.areas.developer_tools --difficulty AL01 --congress 118
 python -m tmd.areas.developer_tools --dual NY12 --congress 118
 ```
 
-The difficulty table is the single most useful diagnostic for
-understanding why an area gets large weight movement.  A target
-with a 5% gap from the proportional share is essentially free; a
-target with a 100% gap will move many weights.
+The difficulty table is the single most useful diagnostic for understanding why an area gets large weight movement. A target with a 5% gap from the proportional share is essentially free; a target with a 100% gap will move many weights.
 
 ## Map of files in this folder
 
@@ -261,5 +193,4 @@ tmd/areas/
 └── weights/                        per-area weight files (output)
 ```
 
-For the sub-folder details see the respective READMEs (linked at the
-top of this file).
+For the sub-folder details see the respective READMEs (linked at the top of this file).

--- a/tmd/areas/README.md
+++ b/tmd/areas/README.md
@@ -1,151 +1,265 @@
-# Area Weighting
+# Sub-national area weights
 
-Generates sub-national area weight files from national PUF-based
-microdata. Area weights let Tax-Calculator produce state-level
-estimates using national input data and growfactors.
+This folder contains everything needed to produce **per-area weight
+files** that adapt the national TMD microdata to a specific state or
+Congressional district.
 
-## Preparing State Targets
+The national TMD file has one record per tax-filing unit and one
+weight per record (`s006`).  Those weights make weighted sums match
+national totals.  An area weight file replaces `s006` with a set of
+**area-specific** weights, so weighted sums of the same records match
+state-level (or CD-level) totals from IRS Statistics of Income (SOI).
+The records do not change; only the weights do.
 
-```bash
-# All 51 states (50 states + DC), ~4 seconds:
-python -m tmd.areas.prepare_targets --scope states
+This README is the user-facing entry point.  For deeper background
+on how the targets are constructed and how the optimizer works, see:
 
-# Specific states:
-python -m tmd.areas.prepare_targets --scope MN,CA,TX
+- [AREA_WEIGHTING_GUIDE.md](AREA_WEIGHTING_GUIDE.md) — concepts,
+  target architecture, recipe contents, file locations.
+- [AREA_WEIGHTING_LESSONS.md](AREA_WEIGHTING_LESSONS.md) — practical
+  lessons from production runs (parameter choices, weight
+  exhaustion, bystander effects, SALT targeting).
+- [weights/README.md](weights/README.md) — weight-file format and
+  how to use the files with Tax-Calculator.
+- [targets/README.md](targets/README.md) — targets-file format.
 
-# Use 2021 SOI shares:
-python -m tmd.areas.prepare_targets --scope states --year 2021
-```
+## What you can do here
 
-**Prerequisite**: TMD national data must exist (`make tmd_files`).
+| Task | Section |
+|---|---|
+| Build all 51 state weight files | [Quickstart](#quickstart) |
+| Build all 436 CD weight files (118th or 119th Congress) | [Quickstart](#quickstart) |
+| Re-solve weights for one area or a few | [Single area](#building-weights-for-a-single-area) |
+| Decide which stage to rerun after an input change | [When to rerun which stage](#when-to-rerun-which-stage) |
+| Check overall quality across many areas | [Multi-area quality report](#multi-area-quality-report) |
+| Inspect a single area in detail | [Individual-area detail report](#individual-area-detail-report) |
+| Diagnose why a specific area is hard to fit | [Single-area diagnostics](#single-area-diagnostics) |
 
-Output: one CSV per state in `tmd/areas/targets/states/`.
+## Prerequisites
 
-## How Targets Work
+The national TMD files must already exist in `tmd/storage/output/`.
+If they do not, run `make data` from the repository root first.
 
-Each target constrains a weighted sum to match a state-level value.
-Targets combine two data sources:
+## Quickstart
 
-- **TMD national totals** provide the level (weighted sums from the
-  national PUF microdata).
-- **IRS SOI state data** provides the geographic distribution (each
-  state's share of the US total, by AGI bin and filing status).
-
-Formula: `state_target = TMD_national × (state_SOI / US_SOI)`
-
-Extended targets also use **Census state/local finance data** for
-SALT distribution and **SOI credit data** for EITC/CTC.
-
-## Target Composition (~178 per state)
-
-**Base targets** (recipe-driven, all 10 AGI bins):
-AGI amounts, total return counts, return counts by filing status,
-wages (amount + nonzero count), taxable interest, pensions, Social
-Security, SALT deduction, partnership/S-corp income.
-
-**Extended targets** (SOI/Census-shared, high-income bins only):
-Taxable pensions, taxable Social Security, IRA distributions, net
-capital gains, dividends, business income, mortgage interest,
-charitable contributions, SALT by source (Census), EITC, CTC.
-
-Filing-status count targets are excluded from the $1M+ AGI bin to
-avoid excessive weight distortion on small cells.
-
-## Solving for State Weights
+The full pipeline for each scope (shares → targets → weights → tests
+and quality report) is wired into `tmd/areas/Makefile`.  From the
+repository root:
 
 ```bash
-# All 51 states, 8 parallel workers:
-python -m tmd.areas.solve_weights --scope states --workers 8
+# All 51 states (50 states + DC), 8 parallel workers:
+make -C tmd/areas states WORKERS=8
 
-# Specific states:
-python -m tmd.areas.solve_weights --scope MN,CA,TX --workers 4
-```
-
-Uses the Clarabel constrained QP solver to find per-record weight
-multipliers that hit each state's targets within 0.5% tolerance.
-
-Output: weight files in `tmd/areas/weights/states/` and solver
-logs alongside them.
-
-## Quality Report
-
-```bash
-python -m tmd.areas.quality_report
-python -m tmd.areas.quality_report --scope CA,NY
-```
-
-Cross-state summary: solve status, target accuracy, weight
-distortion, weight exhaustion, and national aggregation checks.
-
-## Pipeline Modules
-
-**Target preparation** (PR 1):
-
-| Module | Purpose |
-|--------|---------|
-| `prepare_targets.py` | CLI entry point |
-| `prepare/soi_state_data.py` | SOI state CSV ingestion |
-| `prepare/target_sharing.py` | TMD x SOI share computation |
-| `prepare/target_file_writer.py` | Recipe expansion, CSV output |
-| `prepare/extended_targets.py` | Census/SOI extended targets |
-| `prepare/constants.py` | AGI bins, mappings, metadata |
-| `prepare/census_population.py` | State population data |
-
-**Weight solving** (PR 2):
-
-| Module | Purpose |
-|--------|---------|
-| `solve_weights.py` | CLI entry point |
-| `create_area_weights_clarabel.py` | Clarabel QP solver |
-| `batch_weights.py` | Parallel batch runner |
-| `quality_report.py` | Cross-state diagnostics |
-| `sweep_params.py` | Parameter grid search utility |
-
-## Congressional Districts (118th or 119th Congress)
-
-The SOI CD micro-data are published on **117th Congress** boundaries
-for both tax years 2021 and 2022.  The CD pipeline crosswalks those
-data to either 118th or 119th Congress boundaries using a Geocorr
-2022 population-weighted crosswalk.  **Both Congressional sessions
-produce 436 CDs** (435 voting + DC); they differ only in the
-district geography for AL, GA, LA, NY, and NC.
-
-All CD CLI tools require an explicit `--congress 118` or
-`--congress 119` flag — there is no default.
-
-```bash
-# Build shares, targets, and weights for the 118th Congress:
-python -m tmd.areas.prepare_shares  --scope cds --congress 118
-python -m tmd.areas.prepare_targets --scope cds --congress 118
-python -m tmd.areas.solve_weights   --scope cds --congress 118 --workers 16
-
-# Same for the 119th Congress (new AL/GA/LA/NY/NC maps):
-python -m tmd.areas.prepare_shares  --scope cds --congress 119
-python -m tmd.areas.prepare_targets --scope cds --congress 119
-python -m tmd.areas.solve_weights   --scope cds --congress 119 --workers 16
-
-# Or via Makefile convenience targets:
+# All 436 Congressional districts on 118th Congress boundaries:
 make -C tmd/areas cds-118 WORKERS=16
+
+# All 436 CDs on 119th Congress boundaries (different district maps
+# in AL, GA, LA, NY, NC; identical elsewhere):
 make -C tmd/areas cds-119 WORKERS=16
 ```
 
-Outputs are written to per-Congress subdirectories:
+State runs take a few minutes; CD runs take longer because there are
+more areas.  These Make targets always rebuild every stage (shares,
+targets, weights, tests, quality report) — once you know what
+changed upstream, the single-stage commands in
+[When to rerun which stage](#when-to-rerun-which-stage) are
+faster.
 
-- `tmd/areas/targets/cds_118/` and `tmd/areas/targets/cds_119/`
-- `tmd/areas/weights/cds_118/` and `tmd/areas/weights/cds_119/`
-- `tmd/areas/prepare/data/cds_118_shares.csv` and
-  `tmd/areas/prepare/data/cds_119_shares.csv`
+For Congressional districts the choice of Congressional session is required —
+there is no default.  118th and 119th both have 436 districts (435
+voting + DC); only the geographies differ.
 
-The targeting recipe is identical between the two Congressional
-sessions — only the geographic allocation differs.
+## Outputs
 
-See [tmd/areas/prepare/data/README.md](prepare/data/README.md) for
-details on the crosswalk files, their Geocorr settings, and
-validation checks.
+After a successful run you get three kinds of files:
 
-## Lessons Learned
+- **Targets** — one CSV per area in `tmd/areas/targets/states/` or
+  `tmd/areas/targets/cds_118/` (or `cds_119/`).  Each row is one
+  weighted sum the area is asked to match.  See
+  [targets/README.md](targets/README.md) for the file format.
+- **Weights** — one gzipped CSV per area in `tmd/areas/weights/...`,
+  named `<area>_tmd_weights.csv.gz`.  One row per TMD record, with
+  thirteen weight columns (`WT2022` through `WT2034`, one per year).
+  See [weights/README.md](weights/README.md) for how to use these
+  with Tax-Calculator.
+- **Solver log** — `<area>.log` next to each weight file, with the
+  population share used, target accuracy statistics, the weight
+  multiplier distribution, and per-target slack.
 
-See [AREA_WEIGHTING_LESSONS.md](AREA_WEIGHTING_LESSONS.md) for
-practical guidance on parameter tuning, weight exhaustion, SALT
-targeting, dual variable analysis, and recommendations for
-extending to Congressional districts.
+## Building weights for a single area
+
+You can re-solve any single state or single CD by passing its area
+code to `--scope`.  This is much faster than running the full batch
+and is the right approach when you are tuning solver parameters,
+testing a recipe change, or investigating one area.
+
+State codes are two-letter postal codes (lowercase or uppercase).
+CD codes are state code + two-digit district, e.g., `MN01`, `NY12`.
+
+```bash
+# Re-solve one state, using existing target and shares files:
+python -m tmd.areas.solve_weights --scope CA
+
+# A few states at once:
+python -m tmd.areas.solve_weights --scope CA,NY,TX --workers 4
+
+# A single Congressional district (Congress is required):
+python -m tmd.areas.solve_weights --scope MN01 --congress 118
+```
+
+These commands assume the area's targets file already exists.  If
+it does not, or if any of the inputs that feed into targets has
+changed, see the next section.
+
+## When to rerun which stage
+
+A target is constructed as
+
+    target = TMD national sum × geographic share
+
+so a target file goes stale only when one of those inputs changes.
+This table shows what to rerun when something upstream changes:
+
+| What changed | Rerun |
+|---|---|
+| Solver parameter only (e.g., `multiplier_max`) | `solve_weights` |
+| Recipe / target spec | `prepare_targets`, then `solve_weights` |
+| TMD national file (`make data` was rerun) | `prepare_targets`, then `solve_weights` |
+| New SOI vintage, or Census data update | `prepare_shares`, then `prepare_targets`, then `solve_weights` |
+| Adding a previously-unsolved area | `solve_weights --scope <area>` |
+
+`make -C tmd/areas states` (and `cds-118` / `cds-119`) always reruns
+every stage; that is the simplest and safest entry point if you are
+unsure what is stale.  The single-stage commands are the right tool
+once you know which input changed.
+
+## Quality reports
+
+Two reports help you judge whether the area weights are good:
+
+- The **multi-area quality report** is a roll-up across many areas
+  (all states, all CDs, or a list).  Use it to see overall hit
+  rates, weight distortion, and bystander effects.
+- The **individual-area detail report** is the same report restricted
+  to a single area or a small list, with full per-target detail.
+  Use it to dig into one place that looked unusual in the roll-up.
+
+Both modes are produced by the same command,
+`tmd.areas.quality_report`.  The only difference is what you pass
+to `--scope`.
+
+### Multi-area quality report
+
+```bash
+# All 51 states:
+python -m tmd.areas.quality_report --scope states
+
+# All CDs on 118th Congress boundaries (--congress is required):
+python -m tmd.areas.quality_report --scope cds --congress 118
+
+# Save to a file alongside the weights:
+python -m tmd.areas.quality_report --scope states --output
+python -m tmd.areas.quality_report --scope cds --congress 119 --output
+```
+
+The roll-up covers:
+
+- **Solve status** — how many areas solved cleanly, how many used
+  per-area overrides, how many failed.
+- **Target accuracy** — per-area hit rates and the largest
+  violations.
+- **Weight distortion** — distribution of weight multipliers
+  (how far weights moved from population-proportional).
+- **Weight exhaustion** — which records get oversubscribed across
+  areas.
+- **Cross-area aggregation** — sum-of-areas vs national for key
+  variables, so you can confirm the area weights are consistent
+  with the national totals.
+- **Bystander analysis** — variables that are not targeted but are
+  still pushed around by the optimizer; >2% distortion is flagged.
+
+A multi-area run also writes one machine-readable CSV alongside the
+weight files:
+
+- **`quality_report_per_area.csv`** — one row per area, with columns
+  for record counts, weighted returns, weighted AGI, average AGI,
+  the multiplier distribution (median, p95, max, share zero), and
+  two summary diagnostics (`unusualness` and effective sample size
+  `ess`).  This file covers **every** area in the run, so it is the
+  right input when you want to sort, filter, or plot results across
+  the full set.
+
+For CDs, the per-area table inside the text report shows only the
+20 most-distorted areas to keep the report a manageable length; the
+CSV does not truncate.
+
+### Individual-area detail report
+
+To zoom in on one area, pass its code (or a short list) to
+`--scope`.  The report layout is the same; the per-area sections
+just have one entry.
+
+```bash
+# A single state:
+python -m tmd.areas.quality_report --scope CA
+
+# A short list of states:
+python -m tmd.areas.quality_report --scope CA,NY,TX
+
+# A single CD or a list of CDs (Congress is required):
+python -m tmd.areas.quality_report --scope MN01 --congress 118
+python -m tmd.areas.quality_report --scope MN01,MN02 --congress 118
+
+# Send the report to a named file:
+python -m tmd.areas.quality_report --scope CA -o ca_report.txt
+```
+
+### Single-area diagnostics
+
+For a deeper look at a single area, the developer-tools module
+provides two purpose-built diagnostics that are also useful to
+analysts:
+
+```bash
+# Why is this area hard to fit?  Per-target gap from a
+# population-proportionate share, sorted from largest to smallest:
+python -m tmd.areas.developer_tools --difficulty AL01 --congress 118
+
+# Which constraints are most expensive?  Shadow prices from the
+# solved optimization, identifying targets that pull weights hard:
+python -m tmd.areas.developer_tools --dual NY12 --congress 118
+```
+
+The difficulty table is the single most useful diagnostic for
+understanding why an area gets large weight movement.  A target
+with a 5% gap from the proportional share is essentially free; a
+target with a 100% gap will move many weights.
+
+## Map of files in this folder
+
+```
+tmd/areas/
+├── README.md                       (this file)
+├── AREA_WEIGHTING_GUIDE.md         concepts and target architecture
+├── AREA_WEIGHTING_LESSONS.md       lessons from production runs
+├── Makefile                        states / cds-118 / cds-119 pipelines
+├── prepare_shares.py               compute SOI geographic shares
+├── prepare_targets.py              produce per-area target CSVs
+├── solve_weights.py                solve weights (parallel batch)
+├── create_area_weights.py          single-area QP solver core
+├── quality_report.py               multi- and single-area reports
+├── developer_tools.py              difficulty, dual, relaxation cascade
+├── batch_weights.py                parallel-runner support
+├── solver_overrides.py             read per-area override YAML
+├── sweep_params.py                 parameter grid-search utility
+├── make_all.py                     end-to-end driver used in CI
+├── prepare/                        shares + targets building blocks
+│   ├── data/                       SOI inputs and CD crosswalks
+│   ├── recipes/                    target specs
+│   └── (modules)
+├── targets/                        per-area target CSVs (output)
+└── weights/                        per-area weight files (output)
+```
+
+For the sub-folder details see the respective READMEs (linked at the
+top of this file).

--- a/tmd/areas/targets/README.md
+++ b/tmd/areas/targets/README.md
@@ -1,6 +1,8 @@
 # areas / targets
 
-Contains sub-national area targets files.
+Contains sub-national area targets files.  See
+[../README.md](../README.md) for how the targets are built and
+when to rebuild them.
 
 
 ## Targets File Content

--- a/tmd/areas/targets/prepare/README.md
+++ b/tmd/areas/targets/prepare/README.md
@@ -1,7 +1,16 @@
 # areas / targets / prepare
 
-Contains code and data used to generate sub-national area targets files.
+This directory was previously used to host external Quarto-rendered
+documentation sites for state and Congressional district target
+preparation.  Those sites have been retired.  All current
+documentation lives inside this repository:
 
-Preparation documentation is available at the following websites:
--  [Congressional Districts](https://tmd-areas-prepare-cd-targets.netlify.app)
--  [States](https://tmd-areas-prepare-state-targets.netlify.app/)
+- [../../README.md](../../README.md) — main entry point for the
+  area-weighting pipeline.
+- [../../AREA_WEIGHTING_GUIDE.md](../../AREA_WEIGHTING_GUIDE.md) —
+  concepts, target architecture, and the recipe-tuning workflow.
+- [../README.md](../README.md) — targets-file format.
+- [../../prepare/data/README.md](../../prepare/data/README.md) —
+  raw input data and the CD crosswalk files.
+- [../../prepare/recipes/README.md](../../prepare/recipes/README.md)
+  — target recipes (which constraints the optimizer must satisfy).

--- a/tmd/areas/weights/README.md
+++ b/tmd/areas/weights/README.md
@@ -1,3 +1,197 @@
-# areas / weights
+# Area weight files
 
-Contains code to examine sub-national area weights files.
+Output directory for the area-weighting pipeline.  Each successful
+solver run for an area writes a weight file and a solver log here.
+Multi-area quality reports add an all-areas summary CSV.
+
+This directory holds **outputs only** — to (re)build them, see
+[../README.md](../README.md).
+
+## Layout
+
+```
+weights/
+├── states/                 51 states + DC
+│   ├── ca_tmd_weights.csv.gz
+│   ├── ca.log
+│   ├── ...
+│   └── quality_report_per_area.csv     (after a multi-state quality run)
+├── cds_118/                436 CDs on 118th Congress boundaries
+│   ├── al01_tmd_weights.csv.gz
+│   ├── al01.log
+│   └── ...
+└── cds_119/                436 CDs on 119th Congress boundaries
+    └── ...
+```
+
+State files use the lowercase two-letter postal code (e.g., `ca`,
+`ny`, `dc`).  CD files use the lowercase state code plus a
+two-digit district number (e.g., `mn01`, `ny12`).
+
+## Weight file: `<area>_tmd_weights.csv.gz`
+
+A gzipped CSV with **one row per TMD record** (one filing unit), in
+the same row order as the national TMD file
+(`tmd/storage/output/tmd.csv.gz`).  This row alignment is what lets
+you swap an area weight file into Tax-Calculator in place of the
+national weights file.
+
+The columns are weight values, one per calendar year:
+
+```
+WT2022, WT2023, WT2024, WT2025, WT2026, WT2027, WT2028,
+WT2029, WT2030, WT2031, WT2032, WT2033, WT2034
+```
+
+Each value is the area-specific weight for that record in that
+year, on the same scale as the national `s006` weight (i.e.,
+already divided — not in hundredths).  Weighted sums of any TMD
+variable using these weights estimate the corresponding total for
+that area.
+
+Records that the optimizer effectively drops from the area appear
+with weight 0 in every year.  This is normal; a typical state has
+6–10% zero weights.
+
+## Solver log: `<area>.log`
+
+A short text file that records what the solver did for that area.
+Useful when you want to confirm a run was clean without opening the
+full quality report.  Key sections:
+
+- **Population share** used to seed the optimizer.
+- **Pre-solve feasibility** check (LP).
+- **Solver status, iterations, solve time** (Clarabel output).
+- **Target accuracy** — number of targets, how many hit the
+  tolerance band, mean and max relative error.
+- **Multiplier distribution** — histogram of the per-record weight
+  multiplier (`area_weight / population-proportional weight`),
+  including share at zero.
+- **Slack** — for any target the solver could not hit exactly,
+  how far off it landed and which constraint it was.
+
+## All-areas summary: `quality_report_per_area.csv`
+
+Written by `tmd.areas.quality_report` whenever it runs over more
+than one area (e.g., `--scope states` or `--scope cds`).  One row
+per area, with these columns:
+
+| Column | Meaning |
+|---|---|
+| `area` | Area code (e.g., `ca`, `mn01`) |
+| `n_records` | Records with non-zero weight |
+| `pct_zero` | Share of records the solver dropped to zero |
+| `w_median`, `w_p95`, `w_max` | Multiplier distribution (vs. population-proportional baseline of 1.0) |
+| `returns` | Weighted return count |
+| `agi` | Weighted AGI |
+| `avg_agi` | Mean AGI per return |
+| `unusualness` | Summary measure of how far this area's record mix is from the national mix |
+| `ess` | Kish effective sample size (smaller = more weight concentrated on few records) |
+
+The text quality report truncates per-area tables for CDs (top 20
+most-distorted areas) to stay readable; this CSV does not truncate
+and is the right input for cross-area analysis, sorting, or
+plotting.
+
+## Using a weight file
+
+A weight file is just a CSV with one weight per record per year.
+**Computing weighted area totals never requires Tax-Calculator.**
+Tax-Calculator computes per-record tax variables (taxes owed,
+credits, and so on) without using weights at all — weights enter
+only when you aggregate across records.  Once you have a record-
+level file that contains the variables you care about, area
+totals are just `(values * area_weights).sum()`.
+
+### Variables already on the TMD microdata file
+
+For variables that live directly on `tmd.csv.gz` — input variables
+like `e00200` (wages) and `e00300` (taxable interest), the
+demographic variables, and so on — you only need pandas:
+
+```python
+import pandas as pd
+from tmd.storage import STORAGE_FOLDER
+
+tmd = pd.read_csv(STORAGE_FOLDER / "output" / "tmd.csv.gz")
+wts = pd.read_csv(
+    STORAGE_FOLDER.parent / "areas" / "weights" / "states"
+    / "ca_tmd_weights.csv.gz"
+)
+
+ca_wages_2024 = (tmd["e00200"] * wts["WT2024"]).sum()
+```
+
+### Tax-Calculator output variables (income tax, payroll tax, etc.)
+
+Tax-Calculator output variables (such as `iitax`, `payrolltax`,
+`c00100`, `c18300`) are not on `tmd.csv.gz`.  To compute area
+weighted totals of these variables you need a record-level file
+that contains them.  Two common ways to get one:
+
+- Use the unweighted cached outputs that the repo builds during
+  `make data` (`tmd/storage/output/cached_allvars.csv` covers many
+  Tax-Calculator outputs at current law for the TMD tax year).
+- For a different policy or year, run Tax-Calculator once over the
+  national TMD microdata to produce per-record outputs and save
+  them to a CSV.  The choice of national weights does not affect
+  the per-record values.
+
+With such a file in hand, area weighted totals are again a one-line
+pandas expression — no Tax-Calculator call needed at aggregation
+time.
+
+### Computing inside Tax-Calculator with area weights
+
+If you would rather chain calculation and aggregation inside
+Tax-Calculator (for example, to apply a policy reform and read off
+area totals from its tabulators), the area weight file is a
+drop-in replacement for the national `tmd_weights.csv.gz` when
+constructing a `Records` object.  Sketched in Python:
+
+```python
+import taxcalc
+from tmd.imputation_assumptions import TAXYEAR
+from tmd.storage import STORAGE_FOLDER
+
+# National TMD inputs (microdata + growfactors)
+tmd_csv          = STORAGE_FOLDER / "output" / "tmd.csv.gz"
+tmd_growfactors  = STORAGE_FOLDER / "output" / "tmd_growfactors.csv"
+
+# Area weight file (here: California)
+area_weights = (
+    STORAGE_FOLDER.parent / "areas" / "weights" / "states"
+    / "ca_tmd_weights.csv.gz"
+)
+
+records = taxcalc.Records(
+    data=str(tmd_csv),
+    weights=str(area_weights),
+    gfactors=taxcalc.GrowFactors(growfactors_filename=str(tmd_growfactors)),
+    start_year=TAXYEAR,
+    adjust_ratios=None,
+    exact_calculations=True,
+    weights_scale=1.0,
+)
+
+# The same Tax-Calculator policy + calculator setup you use for the
+# national file now produces California-level estimates.
+```
+
+Two things to keep in mind:
+
+- **Year alignment.**  The weight columns cover `WT2022` through
+  `WT2034`.  Tax-Calculator picks the column whose year matches the
+  current calculation year.  Calculating outside that range will
+  fail or use the boundary weights, depending on Tax-Calculator's
+  growth-rule settings.
+- **Sum-of-areas vs national.**  For each year, the sum of all area
+  weights for a record is likely to be close to that record's
+  national `s006`, but for some records the sum may be substantially
+  different.  The `quality_report` cross-area aggregation check
+  reports how this affects national totals built up from the area
+  weights; for policy-relevant variables the discrepancy is small.
+
+For the broader Tax-Calculator workflow with the national TMD
+inputs, see the upstream documentation:
+[taxcalc.pslmodels.org/usage/data.html](https://taxcalc.pslmodels.org/usage/data.html#irs-public-use-data-tmd-csv).

--- a/tmd/areas/weights/README.md
+++ b/tmd/areas/weights/README.md
@@ -107,7 +107,11 @@ totals are just `(values * area_weights).sum()`.
 
 For variables that live directly on `tmd.csv.gz` — input variables
 like `e00200` (wages) and `e00300` (taxable interest), the
-demographic variables, and so on — you only need pandas:
+demographic variables, and so on — you only need pandas.  The
+values stored on `tmd.csv.gz` are in TMD-base-year (2022) dollars,
+so a weighted sum using the matching `WT2022` column gives the
+2022 area total.  For example, weighted total wages in California
+in 2022:
 
 ```python
 import pandas as pd
@@ -119,8 +123,13 @@ wts = pd.read_csv(
     / "ca_tmd_weights.csv.gz"
 )
 
-ca_wages_2024 = (tmd["e00200"] * wts["WT2024"]).sum()
+ca_wages_2022 = (tmd["e00200"] * wts["WT2022"]).sum()
 ```
+
+For a later year you also need to age the underlying values to that
+year using the TMD growfactors (or use the cached Tax-Calculator
+outputs described in the next section, which already contain
+year-aged values).
 
 ### Tax-Calculator output variables (income tax, payroll tax, etc.)
 


### PR DESCRIPTION
 ## Summary                                       
                                                                                                                                                                                                                                                                                                                                         
  First of two PRs for issue #506. Improves the **user-facing**                                                                                                                                                                                                                                                                          
  documentation for area target creation and area weight optimization.                                                                                                                                                                                                                                                                   
  Developer-facing improvements (AREA_WEIGHTING_GUIDE.md restructure,                                                                                                                                                                                                                                                                    
  LESSONS update, module docstrings) come in a separate PR.                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                                                                         
  - New top-level entry point in tmd/areas/README.md, organized by                                                                                                                                                                                                                                                                       
    what a user wants to do (build all states, build all CDs, re-solve                                                                                                                                                                                                                                                                   
    one area, run a quality report on many areas, run one on a single
    area, or run single-area diagnostics).                                                                                                                                                                                                                                                                                               
  - New "When to rerun which stage" table explaining which pipeline
    stages need rerunning when the TMD national file, SOI vintage,                                                                                                                                                                                                                                                                       
    recipe, or solver parameters change.                                                                                                                                                                                                                                                                                                 
  - Multi-area quality report section now documents the                                                                                                                                                                                                                                                                                  
    quality_report_per_area.csv output (covers every area, no                                                                                                                                                                                                                                                                            
    truncation for CDs).                                                                                                                                                                                                                                                                                                                 
  - Rewritten tmd/areas/weights/README.md (was 2 lines, now ~190)                                                                                                                                                                                                                                                                        
    covering weight-file naming, columns, solver-log contents, and                                                                                                                                                                                                                                                                       
    a worked example for computing weighted area totals — both with                                                                                                                                                                                                                                                                      
    pandas alone and inside Tax-Calculator.                                                                                                                                                                                                                                                                                              
  - Top-level README.md gets a short "Sub-national area weights"                                                                                                                                                                                                                                                                         
    section pointing into tmd/areas/.                                                                                                                                                                                                                                                                                                    
  - Retired Quarto-rendered Netlify documentation sites                                                                                                                                                                                                                                                                                  
    (tmd-areas-prepare-{state,cd}-targets.netlify.app) are no longer                                                                                                                                                                                                                                                                     
    referenced; replaced with in-repo cross-links.                                                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                                                                         
  ## Test plan                                                                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
  - [x] Read tmd/areas/weights/README.md
  - [x] Confirm the worked examples run as written (`(tmd["e00200"] * wts["WT2022"]).sum()` for                                                                                                                                                                                                                                                                      
        pandas and the Records sketch for Tax-Calculator).                                                                                                                                                                                                                                                                                  
  - [x] make format and make lint both pass.                                                                                                                                                                                                                                                                                             