### PR TITLE
Improve developer-facing area weights documentation (issue #506)

### DIFF
--- a/tmd/areas/AREA_WEIGHTING_GUIDE.md
+++ b/tmd/areas/AREA_WEIGHTING_GUIDE.md
@@ -1,7 +1,40 @@
 # Area Weighting Guide
 
-How area-specific weights are constructed for TMD, and how to update
-them for new data.
+How area-specific weights are constructed for TMD, and how to extend
+or update them.
+
+> **Audience.**  This guide is for developers and analysts who need
+> to understand the methodology, extend the targeting recipe, or
+> maintain the pipeline as the underlying SOI / Census data evolves.
+> If you only want to *use* existing area weights — build them, run
+> a quality report, or load a weight file into Tax-Calculator — see
+> [README.md](README.md) instead.
+
+## Contents
+
+- [Overview](#overview) — the optimization problem, why QP, AL-01
+  worked example.
+- [Shares: separating geography from levels](#shares-separating-geography-from-levels) —
+  the share × national-sum decomposition.
+- [Architecture](#architecture) — pipeline diagram and the three
+  artifact-change frequencies.
+- [Variable name mapping](#variable-name-mapping) — bridging SOI,
+  TMD, and Tax-Calculator naming.
+- [The target spec](#the-target-spec) — the CSV recipe format that
+  drives production.
+- [Searching for proxies](#searching-for-proxies) — what to do when
+  a TMD variable has no direct SOI counterpart.
+- [Establishing base targets and expanding incrementally](#establishing-base-targets-and-expanding-incrementally) —
+  conservative recipe-extension strategy.
+- [Targeting rules of thumb](#targeting-rules-of-thumb) — eight
+  lessons from CD-pipeline development.
+- [Developer workflow: expanding a recipe](#developer-workflow-expanding-a-recipe) —
+  step-by-step process for adding new targets.
+- [Developer mode](#developer-mode) — the auto-relaxation cascade
+  and override YAML.
+- [Updating for a new year](#updating-for-a-new-year) — SOI
+  vintages, TMD rebuilds, new variables, new area types.
+- [File locations](#file-locations) — where modules and data live.
 
 ## Overview
 
@@ -35,10 +68,14 @@ example, "total wages in the $50K-$75K AGI bin for Alabama CD-1
 should be $2.01 billion."  The constraint matrix `B` encodes which
 records contribute to each target and by how much.
 
-Targets come from IRS Statistics of Income (SOI) data, which
-publishes geographic breakdowns of income, deductions, and credits.
-We scale SOI geographic proportions by TMD national totals to get
-area-level targets that sum exactly to national TMD values.
+Targets come primarily from IRS Statistics of Income (SOI) data,
+which publishes geographic breakdowns of income, deductions, and
+credits.  Census state-and-local-finance data fills in where SOI is
+weak (notably the SALT components, which behave very differently
+under the post-TCJA $10K cap than the SOI deduction series suggests).
+In every case the geographic proportions from the external source are
+scaled by TMD national totals so that area-level targets sum exactly
+to national TMD values.
 
 ### Why this formulation works
 
@@ -88,8 +125,9 @@ two things:
 2. What are national wages in that bin?
    (national level — from TMD)
 
-Item 1 comes from IRS SOI data and changes only with a new SOI
-vintage (~annually).  Item 2 comes from TMD and changes every time
+Item 1 comes from IRS SOI data (or Census state/local-finance data
+for SALT) and changes only when a new vintage of those sources is
+adopted (~annually).  Item 2 comes from TMD and changes every time
 imputations are updated.
 
     share  = area_SOI_value / national_SOI_value
@@ -237,9 +275,10 @@ Lessons learned from CD pipeline development (436 areas).
 
 ### 1. Target difficulty = gap from proportionate share
 
-Use `python -m tmd.areas.developer_tools --difficulty AL01` to see how
-far each target is from what the area would get under population-
-proportionate allocation.  This is the single most useful diagnostic.
+Use `python -m tmd.areas.developer_tools --difficulty AL01 --congress 118`
+to see how far each target is from what the area would get under
+population-proportionate allocation.  This is the single most useful
+diagnostic.
 
 - **Easy (<5% gap):** Solver barely moves weights.  Free to add.
 - **Moderate (5–20%):** Some weight distortion.  Generally fine.
@@ -349,8 +388,8 @@ Pick 3–4 areas spanning the difficulty spectrum:
 - An area similar to your analysis focus
 
 ```bash
-python -m tmd.areas.developer_tools --difficulty AL01
-python -m tmd.areas.developer_tools --difficulty NY12
+python -m tmd.areas.developer_tools --difficulty AL01 --congress 118
+python -m tmd.areas.developer_tools --difficulty NY12 --congress 118
 ```
 
 For each proposed target, check the gap%.  If most areas show
@@ -362,8 +401,8 @@ show >100% gap, consider total-only instead of per-bin.
 Add the new targets to the spec and solve one easy area:
 
 ```bash
-python -m tmd.areas.prepare_targets --scope AL01
-python -m tmd.areas.solve_weights --scope AL01
+python -m tmd.areas.prepare_targets --scope AL01 --congress 118
+python -m tmd.areas.solve_weights   --scope AL01 --congress 118
 ```
 
 Check solve time, violations, and RMSE.  If solve time jumps
@@ -377,7 +416,7 @@ Repeat on NY-12 or another difficult CD.  If it fails, the
 auto-relaxation cascade can find which targets to drop:
 
 ```bash
-python -m tmd.areas.developer_tools --scope NY12 --verbose
+python -m tmd.areas.developer_tools --scope NY12 --congress 118 --verbose
 ```
 
 ### Step 5: Run dual analysis on problem areas
@@ -386,7 +425,7 @@ If a target causes unexpected solver difficulty despite a moderate
 gap%, check the shadow prices:
 
 ```bash
-python -m tmd.areas.developer_tools --dual AL01
+python -m tmd.areas.developer_tools --dual AL01 --congress 118
 ```
 
 High duals identify constraints that conflict with each other.
@@ -398,9 +437,9 @@ it pulls against another target in the same record set.
 Once satisfied with representative areas, run the full batch:
 
 ```bash
-python -m tmd.areas.developer_tools --scope cds --workers 16
-python -m tmd.areas.solve_weights --scope cds --workers 16
-python -m tmd.areas.quality_report --scope cds --output
+python -m tmd.areas.developer_tools --scope cds --congress 118 --workers 16
+python -m tmd.areas.solve_weights   --scope cds --congress 118 --workers 16
+python -m tmd.areas.quality_report  --scope cds --congress 118 --output
 ```
 
 Compare the quality report against the previous version.
@@ -440,20 +479,23 @@ Most areas solve at level 0.  A handful of extreme areas (e.g., NY-12
 
 ```bash
 # LP feasibility check only (fast diagnostic):
-python -m tmd.areas.developer_tools --scope cds --lp-only --workers 16
+python -m tmd.areas.developer_tools --scope cds --congress 118 --lp-only --workers 16
 
 # Full relaxation cascade:
-python -m tmd.areas.developer_tools --scope cds --workers 16
+python -m tmd.areas.developer_tools --scope cds --congress 118 --workers 16
 
 # Debug a single area:
-python -m tmd.areas.developer_tools --scope NY12 --verbose
+python -m tmd.areas.developer_tools --scope NY12 --congress 118 --verbose
 ```
+
+`--congress` is required for any CD scope; state runs do not take
+that flag.
 
 ### Output
 - **Override YAML:** `prepare/recipes/cd_solver_overrides.yaml` —
-  committed to repo, read by production solver
-- **Developer report:** `weights/cds/developer_report.txt` —
-  per-area relaxation details
+  committed to repo, read by production solver.
+- **Developer report:** `weights/cds_118/developer_report.txt` (or
+  `cds_119/...`) — per-area relaxation details.
 
 ### Override file format
 
@@ -485,32 +527,36 @@ customizations automatically.  No manual tuning needed.
 3. **Recompute shares:**
    ```bash
    python -m tmd.areas.prepare_shares --scope states --year 2023
-   python -m tmd.areas.prepare_shares --scope cds --year 2023
+   python -m tmd.areas.prepare_shares --scope cds --congress 118 --year 2023
+   python -m tmd.areas.prepare_shares --scope cds --congress 119 --year 2023
    ```
 
 4. **Regenerate targets:**
    ```bash
-   python -m tmd.areas.prepare_targets --scope cds
+   python -m tmd.areas.prepare_targets --scope cds --congress 118
    ```
 
 5. **Run developer mode:**
    ```bash
-   python -m tmd.areas.developer_tools --scope cds --workers 16
+   python -m tmd.areas.developer_tools --scope cds --congress 118 --workers 16
    ```
 
 6. **Solve weights:**
    ```bash
-   python -m tmd.areas.solve_weights --scope cds --workers 16
+   python -m tmd.areas.solve_weights --scope cds --congress 118 --workers 16
    ```
 
 7. **Quality check:**
    ```bash
-   python -m tmd.areas.quality_report --scope cds --output
+   python -m tmd.areas.quality_report --scope cds --congress 118 --output
    ```
+
+Repeat steps 4–7 with `--congress 119` (and analogous state-scope
+commands) to refresh the other geographies.
 
 ### New TMD rebuild (same SOI year)
 
-Only steps 4-7 needed — shares don't change.
+Only steps 4–7 needed — shares don't change.
 
 ### Adding a new target variable
 
@@ -519,9 +565,12 @@ Only steps 4-7 needed — shares don't change.
 
 2. Add the mapping to `EXTENDED_SHARING_MAPPINGS` in `prepare_shares.py`.
 
-3. Recompute shares: `python -m tmd.areas.prepare_shares --scope cds`
+3. Recompute shares:
+   `python -m tmd.areas.prepare_shares --scope cds --congress 118`.
 
-4. Add a row to the target spec CSV.
+4. Add a row to the target spec CSV (`cd_target_spec.csv` or
+   `state_target_spec.csv` — see
+   [prepare/recipes/README.md](prepare/recipes/README.md)).
 
 5. Regenerate targets and run developer mode to check feasibility.
 
@@ -544,49 +593,51 @@ Only steps 4-7 needed — shares don't change.
 ```
 tmd/areas/
 ├── prepare/
-│   ├── constants.py          # AGI cuts, ALL_SHARING_MAPPINGS, AreaType
-│   ├── recipes/
-│   │   ├── cd_target_spec.csv      # CD recipe (92 targets)
-│   │   ├── state_target_spec.csv   # State recipe (179 targets)
-│   │   ├── cd_solver_overrides.yaml # Per-area solver params
-│   │   ├── cds.json                # [legacy] JSON recipe
-│   │   └── states.json             # [legacy] JSON recipe
-│   ├── data/
+│   ├── constants.py            # AGI cuts, ALL_SHARING_MAPPINGS, AreaType
+│   ├── recipes/                # See prepare/recipes/README.md
+│   │   ├── cd_target_spec.csv      # current — CD recipe (~107 targets)
+│   │   ├── state_target_spec.csv   # current — state recipe (~175 targets)
+│   │   ├── cd_solver_overrides.yaml # current — per-CD solver overrides
+│   │   ├── state_variable_mapping.csv # supports legacy JSON path
+│   │   └── states.json             # legacy — used only by tests
+│   ├── data/                       # See prepare/data/README.md
 │   │   ├── soi_states/             # Raw SOI state CSVs
-│   │   ├── soi_cds/                # Raw SOI CD CSVs
-│   │   ├── cds_shares.csv          # Pre-computed CD shares
-│   │   └── states_shares.csv       # Pre-computed state shares
-│   ├── target_sharing.py     # Share computation, TMD national sums
-│   ├── target_file_writer.py # [legacy] Recipe-based target writing
-│   ├── soi_state_data.py     # State SOI data ingestion
-│   ├── soi_cd_data.py        # CD SOI data + crosswalk
-│   └── extended_targets.py   # State extended targets (Census, credits)
-├── prepare_targets.py        # Target file generation (spec-based)
-├── prepare_shares.py         # Share pre-computation
-├── developer_tools.py         # Auto-relaxation cascade
-├── solve_weights.py          # QP batch solver
-├── create_area_weights.py    # QP solver core (Clarabel)
-├── quality_report.py         # Cross-area quality diagnostics
-├── solver_overrides.py       # Per-area override management
-├── targets/
-│   ├── states/               # Per-state target CSVs
-│   └── cds/                  # Per-CD target CSVs
-└── weights/
-    ├── states/               # Per-state weight files + logs
-    └── cds/                  # Per-CD weight files + logs
+│   │   ├── soi_cds/                # Raw SOI CD CSVs (117th boundaries)
+│   │   ├── states_shares.csv       # Pre-computed state shares
+│   │   ├── cds_118_shares.csv      # Pre-computed CD shares (118th)
+│   │   ├── cds_119_shares.csv      # Pre-computed CD shares (119th)
+│   │   ├── geocorr2022_cd117_to_cd118.csv
+│   │   └── geocorr2022_cd117_to_cd119.csv
+│   ├── target_sharing.py       # Share computation, TMD national sums
+│   ├── target_file_writer.py   # Legacy JSON-recipe target writing (tests)
+│   ├── soi_state_data.py       # State SOI data ingestion
+│   ├── soi_cd_data.py          # CD SOI data + crosswalk
+│   ├── extended_targets.py     # State extended targets (Census, credits)
+│   ├── census_population.py    # State population data
+│   └── validate_crosswalk.py   # CD crosswalk validation
+├── prepare_shares.py           # Share pre-computation (states or cds)
+├── prepare_targets.py          # Target file generation (CSV-spec-based)
+├── solve_weights.py            # Parallel batch QP solver
+├── create_area_weights.py      # Single-area QP solver core (Clarabel)
+├── batch_weights.py            # Parallel-runner support
+├── solver_overrides.py         # Read per-area override YAML
+├── developer_tools.py          # Difficulty / dual / relaxation cascade
+├── quality_report.py           # Multi- and single-area quality reports
+├── sweep_params.py             # Solver parameter grid search
+├── make_all.py                 # End-to-end driver used in CI
+├── targets/                    # Per-area target CSVs (output)
+│   ├── states/
+│   ├── cds_118/
+│   └── cds_119/
+└── weights/                    # Per-area weight files + logs (output)
+    ├── states/
+    ├── cds_118/
+    └── cds_119/
 ```
 
-## Quality Report
+## Quality report
 
-The quality report (`python -m tmd.areas.quality_report --scope cds`)
-provides:
-
-- **Target accuracy:** Per-area hit rates, violation details
-- **Weight distortion:** Multiplier distribution (how far weights moved from population-proportional)
-- **Weight distribution by AGI stub:** National vs sum-of-areas returns and AGI per bin
-- **Weight exhaustion:** Whether records are over/under-used across areas
-- **Cross-area aggregation:** Sum-of-areas vs national for key variables
-- **Bystander analysis:** Distortion of untargeted variables (both aggregate and per-bin)
-
-Use `--output` to auto-save to file.  For CDs/counties, only the top
-20 most-distorted areas are shown in the per-area table.
+For the quality report's contents, the multi-area vs individual-area
+modes, the all-areas `quality_report_per_area.csv` summary, and
+single-area diagnostics (`developer_tools --difficulty` / `--dual`),
+see [README.md](README.md#quality-reports).

--- a/tmd/areas/AREA_WEIGHTING_LESSONS.md
+++ b/tmd/areas/AREA_WEIGHTING_LESSONS.md
@@ -178,21 +178,33 @@ and overseas filers) is excluded from state targeting. Raw SOI
 shares (state/US) are rescaled so that the 51 state shares sum
 to 1.0 for each variable-AGI-bin combination.
 
-## Guidance for Congressional Districts
+## Congressional Districts: how the lessons held up
 
-CDs have not been implemented yet. Expected differences from states:
+The CD pipeline is now in production for both the 118th and 119th
+Congresses (436 areas each — 435 voting districts plus DC).  Of the
+expectations carried over from the state pipeline:
 
-- **435 areas** (vs 51) — grid search infeasible; use state-derived
-  parameter settings
-- **9 AGI bins** (vs 10) — no $1M+ separate bin in SOI CD data
-- **Smaller populations** — more CDs will hit multiplier ceilings;
-  may need different `multiplier_max`
-- **Crosswalk complexity** — SOI uses 117th Congress boundaries for
-  both 2021 and 2022 data; need geocorr crosswalk to map to 118th
-  Congress boundaries
-- **Exhaustion will be worse** — 435 areas competing for the same
-  records means much higher potential exhaustion; `multiplier_max`
-  may need to be lower
+- **436 areas, not 51** — grid search is impractical at this scale,
+  so the production parameters were carried over from the state
+  sweep rather than re-optimized for CDs.
+- **9 AGI bins, not 10** — confirmed: SOI CD data has no separate
+  $1M+ bin, so the CD recipe stops at $500K+.
+- **Smaller populations** — confirmed: a small fraction of districts
+  (~3%) need per-area solver overrides; see
+  `prepare/recipes/cd_solver_overrides.yaml`.
+- **Crosswalk complexity** — SOI publishes CD micro-data on **117th
+  Congress** boundaries for both 2021 and 2022.  The pipeline applies
+  a Geocorr 2022 population-weighted crosswalk to remap to either
+  the 118th or 119th Congress.  Both Congressional sessions share
+  the same targeting recipe and produce 436 CDs; only the geography
+  (and therefore the underlying shares) differs, in five states
+  (AL, GA, LA, NY, NC).  See [prepare/data/README.md](prepare/data/README.md)
+  for the crosswalk files and validation checks.
+- **Exhaustion is real but manageable** — competing across 436 areas
+  for the same records does drive exhaustion higher than in the
+  state pipeline.  Production uses `multiplier_max=25` per the
+  state sweep finding above; the per-area override file handles the
+  outliers (notably NY-12 / Manhattan).
 
 ## Running the parameter sweep
 

--- a/tmd/areas/create_area_weights.py
+++ b/tmd/areas/create_area_weights.py
@@ -23,6 +23,19 @@ Elastic slack variables handle infeasibility gracefully:
     subject to  lb_j <= (Bx)_j + s_lo - s_hi <= ub_j,  s >= 0
 
 Follows the same QP construction as tmd/utils/reweight.py.
+
+This module is a library, not a CLI.  It is called by
+``tmd.areas.solve_weights`` (parallel batch solver, the production
+entry point), ``tmd.areas.developer_tools`` (relaxation cascade),
+and ``tmd.areas.make_all`` (CI driver).  Key public entry points:
+
+    create_area_weights_file(area, ...)   — solve one area, write
+                                             ``<area>_tmd_weights.csv.gz``
+                                             and ``<area>.log``.
+    cd_target_dir(congress)               — directory of CD target
+                                             files for the given session.
+    cd_weight_dir(congress)               — directory of CD weight
+                                             files for the given session.
 """
 
 import sys

--- a/tmd/areas/prepare/recipes/README.md
+++ b/tmd/areas/prepare/recipes/README.md
@@ -1,107 +1,84 @@
-# Target Recipes
+# Target recipes
 
-Target recipes define which constraints the area weight optimizer must
-satisfy. Each recipe is a JSON file paired with a variable mapping CSV.
+A target recipe lists the constraints the area-weight optimizer
+must satisfy.  The production pipeline reads the recipe as a flat
+CSV (one row per target) — what you see in the file is what gets
+solved.
 
-## Files
+## Files in this directory
 
-- `states.json` — State recipe (2022 SOI data). See inline comments
-  for keyword documentation.
-- `state_variable_mapping.csv` — Maps recipe variable names to
-  internal column names in the enhanced targets DataFrame.
+| File | Status | Read by |
+|---|---|---|
+| `state_target_spec.csv` | **current** | `tmd.areas.prepare_targets` (state pipeline) |
+| `cd_target_spec.csv` | **current** | `tmd.areas.prepare_targets` (CD pipeline, both 118 and 119) |
+| `state_variable_mapping.csv` | supports legacy JSON path (see below) | `tests/test_prepare_targets.py` |
+| `cd_solver_overrides.yaml` | **current** | `tmd.areas.solve_weights` and `tmd.areas.developer_tools` |
+| `states.json` | **legacy** — retained for test coverage of the JSON path | `tests/test_prepare_targets.py` |
 
-## State Target Summary (~178 per state)
+The CD recipe is shared across the 118th and 119th Congresses.
+Only the area codes and the underlying SOI shares differ between
+the two; the targeting recipe itself is identical.
 
-### Base targets (from recipe, all 10 AGI bins unless noted)
+## CSV target spec format
 
-| Variable | Measure | Filing Status | AGI Bins | Targets | Description |
-|----------|---------|---------------|----------|---------|-------------|
-| XTOT | population | all | all | 1 | Census state population |
-| c00100 | amount | all | 1–10 | 10 | Adjusted gross income |
-| c00100 | return count | all | 1–10 | 10 | Total returns |
-| c00100 | return count | single | 1–9 | 9 | Single filer returns |
-| c00100 | return count | MFJ | 1–9 | 9 | Married filing jointly returns |
-| c00100 | return count | HoH | 1–9 | 9 | Head of household returns |
-| e00200 | amount | all | 1–10 | 10 | Wages and salaries |
-| e00200 | nz-count | all | 1–9 | 9 | Wage earner count |
-| e00300 | amount | all | 1–10 | 10 | Taxable interest income |
-| e01500 | amount | all | 1–10 | 10 | Pensions (shared by taxable) |
-| e02400 | amount | all | 1–10 | 10 | Social Security (shared by taxable) |
-| c18300 | amount | all | 3–10 | 8 | SALT deduction (after $10K cap) |
-| e26270 | amount | all | 1–10 | 10 | Partnership/S-corp income |
+```csv
+varname,count,scope,fstatus,agilo,agihi,description
+XTOT,0,0,0,-9e+99,9e+99,Population amount all bins
+c00100,0,1,0,-9e+99,1.0,AGI amount <$0K
+c00100,0,1,0,1.0,10000.0,AGI amount $0K-$10K
+...
+eitc,0,1,0,-9e+99,9e+99,EITC amount all bins
+```
 
-Filing-status counts and wage nz-counts are excluded from the $1M+
-bin (stub 10) because dual variable analysis showed these small-cell
-count targets dominate weight distortion. SALT skips the two lowest
-bins where itemization is rare.
+| Column | Meaning |
+|---|---|
+| `varname` | TMD variable name (Tax-Calculator input or output column) |
+| `count` | 0 = dollar amount, 1 = all returns, 2 = nonzero count, 3 = positive count, 4 = negative count |
+| `scope` | 0 = all records (XTOT only), 1 = PUF-derived records, 2 = CPS-derived records |
+| `fstatus` | Filing status: 0 = all, 1 = single, 2 = MFJ, 4 = HoH |
+| `agilo`, `agihi` | AGI bin: lower bound (inclusive) and upper bound (exclusive). `-9e+99` / `9e+99` mean "no bound" |
+| `description` | Human-readable label; ignored by the pipeline |
 
-### Extended targets (stubs 5–10 only, $50K+)
+To add a target, add a row.  To remove one, delete the row.  No
+exclude lists, no indirection.  See [tmd/areas/AREA_WEIGHTING_GUIDE.md](../../AREA_WEIGHTING_GUIDE.md)
+for guidance on which targets are safe to add and which carry
+solver risk.
 
-| Variable | Source | Targets | Description |
-|----------|--------|---------|-------------|
-| e01700 | SOI a01700 | 6 | Taxable pensions |
-| c02500 | SOI a02500 | 6 | Taxable Social Security |
-| e01400 | SOI a01400 | 6 | Taxable IRA distributions |
-| capgains_net | SOI a01000 | 6 | Net capital gains |
-| e00600 | SOI a00600 | 6 | Ordinary dividends |
-| e00900 | SOI a00900 | 6 | Business/professional income |
-| c19200 | SOI a19300 | 6 | Mortgage interest deduction |
-| c19700 | SOI a19700 | 6 | Charitable contributions |
-| e18400 | Census S&L taxes | 6 | SALT income/sales (available) |
-| e18500 | Census property tax | 6 | SALT real estate (available) |
-| eitc | SOI a59660 | 2 | EITC (amount + count, aggregate) |
-| ctc_total | SOI a07225+a11070 | 2 | Child Tax Credit (amount + count, aggregate) |
+For variables that need a SOI proxy (because no direct SOI
+counterpart exists at the right geographic level), the proxy is
+defined in `ALL_SHARING_MAPPINGS` in
+[`../constants.py`](../constants.py) or in `EXTENDED_SHARING_MAPPINGS`
+in [`../../prepare_shares.py`](../../prepare_shares.py).
 
-Extended targets use SOI or Census geographic shares applied to TMD
-national totals. They are restricted to high-income bins ($50K+)
-to avoid noisy low-income data. Credit targets are aggregate
-(one per state, no AGI breakdown).
+## Solver overrides (CDs only)
 
-### AGI bins (states)
+`cd_solver_overrides.yaml` records per-CD solver customizations
+needed for the small fraction of districts (~3% at last count) that
+cannot be solved with the default parameters.  The schema:
 
-| Stub | Range |
-|------|-------|
-| 1 | Under $1,000 |
-| 2 | $1,000 – $10,000 |
-| 3 | $10,000 – $25,000 |
-| 4 | $25,000 – $50,000 |
-| 5 | $50,000 – $75,000 |
-| 6 | $75,000 – $100,000 |
-| 7 | $100,000 – $200,000 |
-| 8 | $200,000 – $500,000 |
-| 9 | $500,000 – $1,000,000 |
-| 10 | $1,000,000 or more |
+```yaml
+_defaults:
+  multiplier_max: 50
+  constraint_tol: 0.005
 
-## Variable Mapping CSV
+ny12:
+  drop_targets:
+    - "c00100/cnt=1/scope=1/agi=[500000.0,9e+99)/fs=0"
+    - "e26270/cnt=0/scope=1/agi=[100000.0,200000.0)/fs=0"
+```
 
-The mapping CSV connects the `varname` in the recipe to the
-`basesoivname` column in the enhanced targets DataFrame produced
-by `target_sharing.py`.
+`tmd.areas.solve_weights` reads this file automatically.  Per-area
+adjustments are produced by `tmd.areas.developer_tools` (the
+relaxation cascade) and committed to this file.
 
-Columns:
+State runs do not currently use a solver-overrides file.
 
-| Column | Description |
-|--------|-------------|
-| varname | TMD variable name used in the recipe JSON |
-| basesoivname | Internal name in the enhanced targets DataFrame |
-| description | Human-readable description |
-| fstatus | Filing status (0=all, 1=single, 2=MFJ, 4=HoH) |
+## Legacy JSON recipe
 
-### Naming conventions for basesoivname
-
-- **Direct SOI names**: `00100`, `00200`, `n1`, `mars1`, etc.
-  Used when the SOI variable directly matches the TMD variable.
-- **Shared names**: `tmd01500_shared_by_soi01700` means TMD variable
-  e01500 (total pensions) uses SOI variable 01700 (taxable pensions)
-  for geographic distribution. The TMD national total is shared
-  across states using the SOI geographic proportions.
-- **XTOT**: Population (Census data, not SOI).
-
-### Adding a new variable
-
-1. Add the variable to the recipe JSON with appropriate scope, count,
-   and fstatus values.
-2. Add a row to the mapping CSV connecting the varname to the correct
-   basesoivname.
-3. If the variable uses SOI sharing, ensure the SOI base variable is
-   in `ALL_SHARING_MAPPINGS` in `constants.py`.
+`states.json` is the older recipe format that paired a JSON file
+with `state_variable_mapping.csv`.  It is no longer used by the
+CLI (`tmd.areas.prepare_targets` always uses the CSV spec above)
+but is kept on disk so that `tests/test_prepare_targets.py` can
+exercise the JSON code path in
+[`../target_file_writer.py`](../target_file_writer.py).  New work
+should use the CSV spec.


### PR DESCRIPTION
Restructure tmd/areas/AREA_WEIGHTING_GUIDE.md as a developer-and- analyst guide: add audience preface and table of contents, fix CD commands missing the now-required --congress flag, repair the out-of-date "File Locations" tree (add prepare_shares, batch_weights, sweep_params, make_all, census_population, validate_crosswalk; show cds_118/cds_119 distinction; mark legacy correctly), and replace the duplicate Quality Report section with a pointer up to the user README that the user documentation PR (PR 1) added. Tweak two passages so the guide describes targets as primarily-SOI plus Census, consistent with PR 1.

Update tmd/areas/AREA_WEIGHTING_LESSONS.md inline: rewrite the Congressional Districts section, which described CDs as "not implemented yet," to instead describe how the state-pipeline expectations actually held up in the production CD pipeline.

Reconcile tmd/areas/prepare/recipes/README.md with what the CLI actually loads: cd_target_spec.csv and state_target_spec.csv are the production specs; states.json is retained only for the test that exercises the legacy JSON code path; cds.json no longer exists. Document the CSV spec format (columns, count/scope/fstatus codes), the cd_solver_overrides.yaml schema, and why the JSON recipe is still on disk.

Add a "Key entry points / used by" section to the
tmd/areas/create_area_weights.py module docstring so a developer reading the file knows it is a library called by solve_weights, developer_tools, and make_all.