### PR TITLE
Pin `taxcalc` version to 6.5.3 in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.11,<3.14",
     install_requires=[
-        "taxcalc>=6.5.3",
+        "taxcalc==6.5.3",
         "numpy",
         "pandas>=3.0.2",
         "clarabel",


### PR DESCRIPTION
Insulates TMD data preparation from bug fixes in [taxcalc 6.6.0](https://github.com/PSLmodels/Tax-Calculator/blob/master/docs/about/releases.md#2026-05-18-release-660).

Using taxcalc 6.6.0 causes these TMD test errors:
```
tests/test_imputed_variables.py:173: ValueError
E           ValueError: 
E           IMPUTED VARIABLE DEDUCTION BENEFIT ACT-vs-EXP DIFFS USING 2022 DATA:
E           DIFF:OTM,totben,act,exp,atol= 23.71 23.68 0.01
E           DIFF:TIP,totben,act,exp,atol= 7.11 7.08 0.01
E           DIFF:TIP,affben,act,exp,atol= 1401.0 1397 1.0
E           DIFF:ALL,totben,act,exp,atol= 58.97 58.92 0.01
tests/test_weights.py:83: ValueError
E           ValueError: WEIGHT FINGERPRINT MISMATCH USING 2022 DATA:
E             p50: actual=398.097355, expected=398.084
E             p75: actual=1437.78516, expected=1437.77
tests/test_tax_expenditures.py:55: ValueError
E           ValueError: 
E           ACT-vs-EXP TAX EXPENDITURE DIFFERENCES USING 2022 DATA:
E           iitax,act,exp,atol,rtol= 2332.1 2331.3 0.1 1e-05
E           cgqd_tax_preference,act,exp,atol,rtol= 179.8 179.6 0.1 1e-05
E           qbid,act,exp,atol,rtol= 55.0 55.9 0.1 1e-05
```
