### PR TITLE
Use `soi_iitax` parameter introduced in Tax-Calculator 6.6.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For Tax-Calculator results generated when using these TMD input files,
 see [this
 folder](https://github.com/PSLmodels/Tax-Calculator/tree/master/taxcalc/cli/input_data_tests).
 
-The **current TMD version is 2.1.1**, which was released on May 24,
+The **current TMD version is 2.1.1**, which was released on May 28,
 2026, and is the same as TMD version 2.0.0 except that Tax-Calculator
 version 6.6.1 (instead of 6.5.3) is used to generate the TMD files.
 

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ For Tax-Calculator results generated when using these TMD input files,
 see [this
 folder](https://github.com/PSLmodels/Tax-Calculator/tree/master/taxcalc/cli/input_data_tests).
 
-The **current TMD version is 2.1.0**, which was released on May 22,
+The **current TMD version is 2.1.1**, which was released on May 24,
 2026, and is the same as TMD version 2.0.0 except that Tax-Calculator
-version 6.6.0 (instead of 6.5.3) is used to generate the TMD files.
+version 6.6.1 (instead of 6.5.3) is used to generate the TMD files.
 
-The current TMD 2.1.0 version differs from the 2.0.0 version only
+The current TMD 2.1.1 version differs from the 2.0.0 version only
 slightly in the national weights (all the `WT*` columns in the
 `tmd_weights.csv.gz` file and just the `s006` variable in the
 `tmd.csv.gz` file); the non-weights input variables in the
 `tmd.csv.gz` file and the contents of `tmd_growfactors.csv` file are
-unchanged.  When using version 2.1.0 to generate **sub-national
+unchanged.  When using version 2.1.1 to generate **sub-national
 weights**, there will be (presumably small) differences from the
 sub-national weights generated using version 2.0.0; however, the
 sub-national weights fingerprints have not yet been updated.

--- a/README.md
+++ b/README.md
@@ -20,8 +20,7 @@ slightly in the national weights (all the `WT*` columns in the
 unchanged.  When using version 2.1.0 to generate **sub-national
 weights**, there will be (presumably small) differences from the
 sub-national weights generated using version 2.0.0; however, the
-sub-national weights fingerprints have not been updated in this pull
-request.
+sub-national weights fingerprints have not yet been updated.
 
 The prior TMD 2.0.0 version included the following significant
 improvements:

--- a/setup.py
+++ b/setup.py
@@ -2,11 +2,11 @@ from setuptools import setup, find_packages
 
 setup(
     name="tmd",
-    version="2.1.0",
+    version="2.1.1",
     packages=find_packages(),
     python_requires=">=3.11,<3.14",
     install_requires=[
-        "taxcalc==6.6.0",
+        "taxcalc==6.6.1",
         "numpy",
         "pandas>=3.0.2",
         "clarabel",

--- a/tests/test_imputed_variables.py
+++ b/tests/test_imputed_variables.py
@@ -7,7 +7,7 @@ auto_loan_interest.
 import numpy as np
 import pytest
 import taxcalc
-from tmd.imputation_assumptions import TAXYEAR, CREDIT_CLAIMING
+from tmd.imputation_assumptions import TAXYEAR, SOI_IITAX_SPEC, CREDIT_CLAIMING
 from tests.conftest import create_tmd_records
 
 
@@ -124,6 +124,7 @@ def test_obbba_deduction_tax_benefits(
     )
     # create baseline_sim Calculator object for simyear and get its output
     pol = taxcalc.Policy()
+    pol.implement_reform(SOI_IITAX_SPEC)
     pol.implement_reform(CREDIT_CLAIMING)
     baseline_sim = taxcalc.Calculator(policy=pol, records=recs)
     baseline_sim.advance_to_year(simyear)
@@ -141,6 +142,7 @@ def test_obbba_deduction_tax_benefits(
     for ded, info in deductions.items():
         # create reform Calculator object for simyear
         reform_policy = taxcalc.Policy()
+        reform_policy.implement_reform(SOI_IITAX_SPEC)
         reform_policy.implement_reform(CREDIT_CLAIMING)
         reform_policy.implement_reform(info["reform_dict"])
         reform_sim = taxcalc.Calculator(policy=reform_policy, records=recs)

--- a/tests/test_revenue_levels_cbo.py
+++ b/tests/test_revenue_levels_cbo.py
@@ -18,7 +18,7 @@ import yaml
 import pytest
 import taxcalc
 
-from tmd.imputation_assumptions import TAXYEAR, CREDIT_CLAIMING
+from tmd.imputation_assumptions import TAXYEAR, SOI_IITAX_SPEC, CREDIT_CLAIMING
 
 # Per-year relative tolerance for all three aggregates.
 RELTOL = {
@@ -45,6 +45,7 @@ def test_revenue_levels_cbo(
         exp = yaml.safe_load(f)
 
     pol = taxcalc.Policy()
+    pol.implement_reform(SOI_IITAX_SPEC)
     pol.implement_reform(CREDIT_CLAIMING)
     rec = taxcalc.Records(
         data=tmd_variables,

--- a/tests/test_soi_sanity_2022.py
+++ b/tests/test_soi_sanity_2022.py
@@ -49,7 +49,7 @@ import pandas as pd
 import taxcalc
 
 from tmd.storage import STORAGE_FOLDER
-from tmd.imputation_assumptions import TAXYEAR, CREDIT_CLAIMING
+from tmd.imputation_assumptions import TAXYEAR, SOI_IITAX_SPEC, CREDIT_CLAIMING
 
 SOI_YEAR = 2022
 RELATIVE_TOLERANCE = 0.01
@@ -90,6 +90,7 @@ def test_soi_sanity_2022(
     # using the post-calc_all arrays keeps one consistent source for
     # all five aggregates.
     pol = taxcalc.Policy()
+    pol.implement_reform(SOI_IITAX_SPEC)
     pol.implement_reform(CREDIT_CLAIMING)
     recs = taxcalc.Records(
         data=tmd_variables,

--- a/tmd/create_taxcalc_cached_files.py
+++ b/tmd/create_taxcalc_cached_files.py
@@ -6,7 +6,7 @@ import numpy as np
 import pandas as pd
 import taxcalc
 from tmd.storage import STORAGE_FOLDER, CACHED_TAXCALC_VARIABLES
-from tmd.imputation_assumptions import TAXYEAR, CREDIT_CLAIMING
+from tmd.imputation_assumptions import TAXYEAR, SOI_IITAX_SPEC, CREDIT_CLAIMING
 
 INFILE_PATH = STORAGE_FOLDER / "output" / "tmd.csv.gz"
 WTFILE_PATH = STORAGE_FOLDER / "output" / "tmd_weights.csv.gz"
@@ -22,6 +22,7 @@ def create_cached_files():
     # Construct Records directly (bypassing tmd_constructor which
     # hardcodes start_year=2021 in the taxcalc library).
     pol = taxcalc.Policy()
+    pol.implement_reform(SOI_IITAX_SPEC)
     pol.implement_reform(CREDIT_CLAIMING)
     rec = taxcalc.Records(
         data=pd.read_csv(INFILE_PATH),

--- a/tmd/datasets/cps.py
+++ b/tmd/datasets/cps.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 import taxcalc
 from tmd.storage import STORAGE_FOLDER
 from tmd.imputation_assumptions import (
+    SOI_IITAX_SPEC,
     CREDIT_CLAIMING,
     CPS_FILER_MIN_INCOME,
     CPS_TAXABLE_INTEREST_FRACTION,
@@ -357,6 +358,7 @@ def _is_tax_filer(tcdf: pd.DataFrame, taxyear: int) -> pd.Series:
         weights_scale=1.0,
     )
     pol = taxcalc.Policy()
+    pol.implement_reform(SOI_IITAX_SPEC)
     pol.implement_reform(CREDIT_CLAIMING)
     calc = taxcalc.Calculator(records=rec, policy=pol)
     calc.advance_to_year(taxyear)

--- a/tmd/imputation_assumptions.py
+++ b/tmd/imputation_assumptions.py
@@ -76,3 +76,6 @@ POP_FILE = {
     2022: "cbo26_population.yaml",
 }
 POPULATION_FILE = POP_FILE[TAXYEAR]
+
+# Tax-Calculator reform dictionary to produce SOI statistics
+SOI_IITAX_SPEC = {"soi_iitax": {2013: True}}

--- a/tmd/utils/soi_replication.py
+++ b/tmd/utils/soi_replication.py
@@ -1,10 +1,11 @@
 import pandas as pd
 import taxcalc
-from tmd.imputation_assumptions import CREDIT_CLAIMING
+from tmd.imputation_assumptions import SOI_IITAX_SPEC, CREDIT_CLAIMING
 
 
 def taxcalc_to_soi(puf: pd.DataFrame, year: int) -> pd.DataFrame:
     pol = taxcalc.Policy()
+    pol.implement_reform(SOI_IITAX_SPEC)
     pol.implement_reform(CREDIT_CLAIMING)
     rec = taxcalc.Records(
         data=puf,

--- a/tmd/utils/taxcalc_output.py
+++ b/tmd/utils/taxcalc_output.py
@@ -7,7 +7,7 @@ import pathlib
 import numpy as np
 import pandas as pd
 import taxcalc
-from tmd.imputation_assumptions import CREDIT_CLAIMING
+from tmd.imputation_assumptions import SOI_IITAX_SPEC, CREDIT_CLAIMING
 
 
 def add_taxcalc_outputs(
@@ -47,6 +47,7 @@ def add_taxcalc_outputs(
         weights_scale=1.0,
     )
     pol = taxcalc.Policy()
+    pol.implement_reform(SOI_IITAX_SPEC)
     pol.implement_reform(CREDIT_CLAIMING)
     if reform:
         pol.implement_reform(reform)


### PR DESCRIPTION
Set `soi_iitax` to true in all uses of the Tax-Calculator 6.6.1 Policy object.

The revisions in this PR cause no changes in TMD input data file contents.
