### PR TITLE
Require taxcalc version 6.6.1 or higher in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     packages=find_packages(),
     python_requires=">=3.11,<3.14",
     install_requires=[
-        "taxcalc==6.6.1",
+        "taxcalc>=6.6.1",
         "numpy",
         "pandas>=3.0.2",
         "clarabel",


### PR DESCRIPTION
No change in data preparation logic or results.