### PR TITLE
Change `PosixPath` to `Path` so as to avoid Windows-specific bugs

### DIFF
--- a/tmd/utils/taxcalc_output.py
+++ b/tmd/utils/taxcalc_output.py
@@ -29,11 +29,11 @@ def add_taxcalc_outputs(
     Returns:
         pd.DataFrame: The Tax-Calculator output.
     """
-    if isinstance(weights, pathlib.PosixPath):
+    if isinstance(weights, pathlib.Path):
         wghts = str(weights)
     else:
         wghts = weights
-    if isinstance(growfactors, pathlib.PosixPath):
+    if isinstance(growfactors, pathlib.Path):
         growf = taxcalc.GrowFactors(growfactors_filename=str(growfactors))
     else:
         growf = growfactors


### PR DESCRIPTION
Fixes issue #522, which was caused by a Window-specific bug in the code.

@mpkeightley, are you planning to use the TMD code to generate sub-national weights (for states or Congressional districts)?  Please let us know if you are, because there are a few Window-specific bugs in the area code.

Again, thanks for the informative bug report and we look forward to any other feedback you can provide about your experience using the TMD code.

