### PR TITLE
Fix three statements that could cause problems on Windows

### DIFF
--- a/tests/test_solve_weights.py
+++ b/tests/test_solve_weights.py
@@ -174,7 +174,7 @@ def test_parse_log_solved():
     ) as f:
         f.write(log_content)
         f.flush()
-        result = parse_log(Path(f.name))
+    result = parse_log(Path(f.name))
 
     assert result["status"] == "Solved"
     assert result["solve_time"] == pytest.approx(3.14)

--- a/tmd/national_targets/extract_irs_to_csv.py
+++ b/tmd/national_targets/extract_irs_to_csv.py
@@ -227,7 +227,7 @@ def extract_all(
 
             df.to_csv(out_path, index=False)
             rel = out_path.relative_to(Path.cwd())
-            print(f"{len(df)} rows → {rel}")
+            print(f"{len(df)} rows -> {rel}")
             count += 1
 
     return count

--- a/tmd/national_targets/potential_targets_to_soi.py
+++ b/tmd/national_targets/potential_targets_to_soi.py
@@ -433,7 +433,7 @@ def compare_with_existing_soi(new_df, existing_soi_path, year=2021):
 if __name__ == "__main__":
     from tmd.storage import STORAGE_FOLDER
 
-    print("Converting irs_aggregate_values.csv → soi.csv format...")
+    print("Converting irs_aggregate_values.csv -> soi.csv format...")
     print()
 
     # Exclude rentroyalty and estateincome for 2022 (PUF variables


### PR DESCRIPTION
These changes have no effect on non-Windows platforms: all the tests pass and the three generated national TMD data files are the same as before these changes.

Commit  [f20d1f1](https://github.com/PSLmodels/tax-microdata-benchmarking/commit/f20d1f16895789f2eb10cafeffaf0e20415fd05d) fixes this issue:
```
  A temp-file reopened while open (fails on Windows)

  tests/test_solve_weights.py:172-177
  with tempfile.NamedTemporaryFile(mode="w", suffix=".log", delete=False) as f:
      f.write(log_content)
      f.flush()
      result = parse_log(Path(f.name))   # reopens f.name while f is still open

  On Linux/macOS a file can be opened by a second handle while the first is
  open. On Windows the file is locked, so parse_log()'s open() raises
  PermissionError. The fix is to close the temp file before reopening — move the
  parse_log call outside the with block.
```

Commit [0ec32bc](https://github.com/PSLmodels/tax-microdata-benchmarking/commit/0ec32bcad994fd1700401b67f4dd71f72c44dcd0) fixes this issue:
```
  Console-encoding crash on Windows — non-ASCII in print()

  tmd/national_targets/extract_irs_to_csv.py:230 and
  tmd/national_targets/potential_targets_to_soi.py:436 both print() a →
  (U+2192).

  On Windows, when stdout is redirected to a file or pipe, Python encodes using
  the locale code page (cp1252), which has no → → UnicodeEncodeError. (Other
  non-ASCII output like —, ±, × is in cp1252, so those are safe; →, ←, Σ, ✓ are
  not.) Note the log files written with explicit encoding="utf-8" and the
  io.StringIO capture in batch_weights.py are all safe — only direct console
  prints are at risk.
```
