### PR TITLE
Pin `scikit-learn` package to 1.8.0 version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
         "numpy",
         "pandas>=3.0.2",
         "clarabel",
-        "scikit-learn",
+        "scikit-learn==1.8.0",
         "scipy",
         "xlrd",
         "openpyxl",


### PR DESCRIPTION
New 1.9.0 version generates different TMD "make data" results, so this PR pins the `scikit-learn` package to the 1.8.0 version pending further investigation.

The 1.9.0 release notes are [here](https://scikit-learn.org/stable/whats_new/v1.9.html).

cc: @donboyd5